### PR TITLE
Add clip: Aligning VLM Assistants with Personalized Situated Cognition

### DIFF
--- a/2025/06/arxiv.org/2025-06-01_aligning-vlm-assistants-with-personalized-situated-cognition.md
+++ b/2025/06/arxiv.org/2025-06-01_aligning-vlm-assistants-with-personalized-situated-cognition.md
@@ -1,0 +1,34 @@
+<!-- metadata -->
+- **title**: Aligning VLM Assistants with Personalized Situated Cognition
+- **source**: https://arxiv.org/abs/2506.00930
+- **author**: Li, Yongqi, Zhou, Shen, Li, Xiaohu, Miao, Xin, Wen, Jintao, Xu, Mayi, Chen, Jianhao, Pan, Birong, Kang, Hankun, Zhu, Yuanyuan, Zhong, Ming, Qian, Tieyun
+- **published**: 2025-06-01T00:00:00Z
+- **fetched**: 2025-06-04T02:07:35.576763Z
+- **tags**: codex, vlm, alignment, personalization, ai
+- **image**: /static/browse/0.3.4/images/arxiv-logo-fb.png
+
+## 概要 / Summary
+VLMアシスタントを個人の状況認識に合わせるため、**Role-Set**による個人モデルと行動評価を導入。18k例の**PCogAlignBench**を構築し、報酬モデル**PCogAlign**で効果を検証。
+
+## 本文 / Article
+
+[Submitted on 1 Jun 2025]
+
+Title:Aligning VLM Assistants with Personalized Situated Cognition
+==================================================================
+
+Authors:[Yongqi Li](https://arxiv.org/search/cs?searchtype=author&query=Li,+Y), [Shen Zhou](https://arxiv.org/search/cs?searchtype=author&query=Zhou,+S), [Xiaohu Li](https://arxiv.org/search/cs?searchtype=author&query=Li,+X), [Xin Miao](https://arxiv.org/search/cs?searchtype=author&query=Miao,+X), [Jintao Wen](https://arxiv.org/search/cs?searchtype=author&query=Wen,+J), [Mayi Xu](https://arxiv.org/search/cs?searchtype=author&query=Xu,+M), [Jianhao Chen](https://arxiv.org/search/cs?searchtype=author&query=Chen,+J), [Birong Pan](https://arxiv.org/search/cs?searchtype=author&query=Pan,+B), [Hankun Kang](https://arxiv.org/search/cs?searchtype=author&query=Kang,+H), [Yuanyuan Zhu](https://arxiv.org/search/cs?searchtype=author&query=Zhu,+Y), [Ming Zhong](https://arxiv.org/search/cs?searchtype=author&query=Zhong,+M), [Tieyun Qian](https://arxiv.org/search/cs?searchtype=author&query=Qian,+T)
+
+View a PDF of the paper titled Aligning VLM Assistants with Personalized Situated Cognition, by Yongqi Li and 11 other authors
+
+[View PDF](/pdf/2506.00930)
+[HTML (experimental)](https://arxiv.org/html/2506.00930v1)
+> Abstract:Vision-language models (VLMs) aligned with general human objectives, such as being harmless and hallucination-free, have become valuable assistants of humans in managing visual tasks. However, people with diversified backgrounds have different cognition even in the same situation. Consequently, they may have personalized expectations for VLM assistants. This highlights the urgent need to align VLM assistants with personalized situated cognition for real-world assistance. To study this problem, we first simplify it by characterizing individuals based on the sociological concept of Role-Set. Then, we propose to evaluate the individuals' actions to examine whether the personalized alignment is achieved. Further, we construct a benchmark named PCogAlignBench, which includes 18k instances and 20 individuals with different Role-Sets. Finally, we present a framework called PCogAlign, which constructs a cognition-aware and action-based reward model for personalized alignment. Experimental results and human evaluations demonstrate the reliability of the PCogAlignBench and the effectiveness of our proposed PCogAlign. We will open-source the constructed benchmark and code at [this https URL](https://github.com/NLPGM/PCogAlign).
+
+|  |  |
+| --- | --- |
+| Comments: | Accepted to ACL 2025 (main), camera-ready version |
+| Subjects: | Artificial Intelligence (cs.AI); Computation and Language (cs.CL) |
+| Cite as: | [arXiv:2506.00930](https://arxiv.org/abs/2506.00930) [cs.AI] |
+|  | (or  [arXiv:2506.00930v1](https://arxiv.org/abs/2506.00930v1) [cs.AI] for this version) |
+|  | <https://doi.org/10.48550/arXiv.2506.00930> Focus to learn more  arXiv-issued DOI via DataCite |


### PR DESCRIPTION
## Summary
- scrape arXiv abstract for *Aligning VLM Assistants with Personalized Situated Cognition*
- convert page to Markdown with readability-lxml and markdownify
- include metadata, Japanese summary and article body

## Testing
- `pip install readability-lxml markdownify`
- `pip install requests`


------
https://chatgpt.com/codex/tasks/task_e_683faa0889cc832eb5667ba8cf7d95bf