### PR TITLE
Add clip: Neuro2Semantic EEG framework

### DIFF
--- a/2025/06/arxiv.org/2025-05-31_neuro2semantic-a-transfer-learning-framework-for-semantic-reconstruction-of-cont.md
+++ b/2025/06/arxiv.org/2025-05-31_neuro2semantic-a-transfer-learning-framework-for-semantic-reconstruction-of-cont.md
@@ -1,0 +1,34 @@
+<!-- metadata -->
+- **title**: Neuro2Semantic: A Transfer Learning Framework for Semantic Reconstruction of Continuous Language from Human Intracranial EEG
+- **source**: https://arxiv.org/abs/2506.00381
+- **author**: Siavash Shams, Richard Antonello, Gavin Mischler, Stephan Bickel, Ashesh Mehta, Nima Mesgarani
+- **published**: 2025-05-31T00:00:00Z
+- **fetched**: 2025-06-04T04:41:22Z
+- **tags**: codex, neuroscience, eeg, transfer learning
+- **image**: /static/browse/0.3.4/images/arxiv-logo-fb.png
+
+## 概要 / Summary
+新提案の**Neuro2Semantic**はiEEGから連続言語を復元する転移学習フレームワーク。**LSTM**アダプタで信号をテキスト埋め込みへ整合し、補正モジュールで自然文を生成。30分のデータでも既存手法を上回り、BCI応用へ期待。
+
+## 本文 / Article
+
+[Submitted on 31 May 2025]
+
+Title:Neuro2Semantic: A Transfer Learning Framework for Semantic Reconstruction of Continuous Language from Human Intracranial EEG
+==================================================================================================================================
+
+Authors:[Siavash Shams](https://arxiv.org/search/cs?searchtype=author&query=Shams,+S), [Richard Antonello](https://arxiv.org/search/cs?searchtype=author&query=Antonello,+R), [Gavin Mischler](https://arxiv.org/search/cs?searchtype=author&query=Mischler,+G), [Stephan Bickel](https://arxiv.org/search/cs?searchtype=author&query=Bickel,+S), [Ashesh Mehta](https://arxiv.org/search/cs?searchtype=author&query=Mehta,+A), [Nima Mesgarani](https://arxiv.org/search/cs?searchtype=author&query=Mesgarani,+N)
+
+View a PDF of the paper titled Neuro2Semantic: A Transfer Learning Framework for Semantic Reconstruction of Continuous Language from Human Intracranial EEG, by Siavash Shams and 5 other authors
+
+[View PDF](/pdf/2506.00381)
+[HTML (experimental)](https://arxiv.org/html/2506.00381v1)
+> Abstract:Decoding continuous language from neural signals remains a significant challenge in the intersection of neuroscience and artificial intelligence. We introduce Neuro2Semantic, a novel framework that reconstructs the semantic content of perceived speech from intracranial EEG (iEEG) recordings. Our approach consists of two phases: first, an LSTM-based adapter aligns neural signals with pre-trained text embeddings; second, a corrector module generates continuous, natural text directly from these aligned embeddings. This flexible method overcomes the limitations of previous decoding approaches and enables unconstrained text generation. Neuro2Semantic achieves strong performance with as little as 30 minutes of neural data, outperforming a recent state-of-the-art method in low-data settings. These results highlight the potential for practical applications in brain-computer interfaces and neural decoding technologies.
+
+|  |  |
+| --- | --- |
+| Comments: | Accepted at Interspeech 2025 Code at [this https URL](https://github.com/SiavashShams/neuro2semantic) |
+| Subjects: | Computation and Language (cs.CL); Audio and Speech Processing (eess.AS); Signal Processing (eess.SP) |
+| Cite as: | [arXiv:2506.00381](https://arxiv.org/abs/2506.00381) [cs.CL] |
+|  | (or  [arXiv:2506.00381v1](https://arxiv.org/abs/2506.00381v1) [cs.CL] for this version) |
+|  | <https://doi.org/10.48550/arXiv.2506.00381> Focus to learn more  arXiv-issued DOI via DataCite |


### PR DESCRIPTION
## Summary
- add a new clip for the arXiv paper "Neuro2Semantic"

## Testing
- `pip install readability-lxml markdownify bs4 requests python-dateutil`


------
https://chatgpt.com/codex/tasks/task_e_683fcde60094832e82e63a1aa09fb4a5