### PR TITLE
Add clip: Shuffle PatchMix Augmentation with Confidence-Margin

### DIFF
--- a/2025/06/arxiv.org/2025-06-04_shuffle-patchmix-augmentation-with-confidence-margin-weighted-pseudo-labels-for-enhanced-source-free-domain-adaptation.md
+++ b/2025/06/arxiv.org/2025-06-04_shuffle-patchmix-augmentation-with-confidence-margin-weighted-pseudo-labels-for-enhanced-source-free-domain-adaptation.md
@@ -1,0 +1,36 @@
+<!-- metadata -->
+- **title**: Shuffle PatchMix Augmentation with Confidence-Margin Weighted Pseudo-Labels for Enhanced Source-Free Domain Adaptation
+- **source**: https://arxiv.org/abs/2505.24216
+- **author**: Pulakurthi, Prasanna Reddy, Rabbani, Majid, Heard, Jamison, Dianat, Sohail, de Melo, Celso M., Rao, Raghuveer
+- **published**: 2025/05/30T00:00:00Z
+- **fetched**: 2025-06-04T04:41:37Z
+- **tags**: codex, arxiv
+- **image**: /static/browse/0.3.4/images/arxiv-logo-fb.png
+
+## 概要 / Summary
+Shuffle PatchMix(SPM)と信頼度重み付け擬似ラベルにより、Source-Free Domain Adaptationを改善。**SPM**で多様な画像生成、**pseudo-label**重み付けでPACs等でSOTAを達成。
+
+## 本文 / Article
+[Submitted on 30 May 2025]
+
+Title:Shuffle PatchMix Augmentation with Confidence-Margin Weighted Pseudo-Labels for Enhanced Source-Free Domain Adaptation
+============================================================================================================================
+
+View a PDF of the paper titled Shuffle PatchMix Augmentation with Confidence-Margin Weighted Pseudo-Labels for Enhanced Source-Free Domain Adaptation, by Prasanna Reddy Pulakurthi and 5 other authors
+
+[View PDF](/pdf/2505.24216)
+[HTML (experimental)](https://arxiv.org/html/2505.24216v1)
+> Abstract:This work investigates Source-Free Domain Adaptation (SFDA), where a model adapts to a target domain without access to source data. A new augmentation technique, Shuffle PatchMix (SPM), and a novel reweighting strategy are introduced to enhance performance. SPM shuffles and blends image patches to generate diverse and challenging augmentations, while the reweighting strategy prioritizes reliable pseudo-labels to mitigate label noise. These techniques are particularly effective on smaller datasets like PACS, where overfitting and pseudo-label noise pose greater risks. State-of-the-art results are achieved on three major benchmarks: PACS, VisDA-C, and DomainNet-126. Notably, on PACS, improvements of 7.3% (79.4% to 86.7%) and 7.2% are observed in single-target and multi-target settings, respectively, while gains of 2.8% and 0.7% are attained on DomainNet-126 and VisDA-C. This combination of advanced augmentation and robust pseudo-label reweighting establishes a new benchmark for SFDA. The code is available at: [this https URL](https://github.com/PrasannaPulakurthi/SPM)
+
+Submission history
+------------------
+
+From: Prasanna Reddy Pulakurthi [
+
+[view email](/show-email/4bf2ec67/2505.24216)
+
+]
+
+**[v1]**
+
+Fri, 30 May 2025 05:02:42 UTC (354 KB)


### PR DESCRIPTION
## Summary
- scrape arXiv page for *Shuffle PatchMix Augmentation with Confidence-Margin Weighted Pseudo-Labels for Enhanced Source-Free Domain Adaptation*
- include metadata, summary in Japanese, and markdown of the article

## Testing
- `pip install requests readability-lxml markdownify`


------
https://chatgpt.com/codex/tasks/task_e_683fce2c8b28832e860a30349d83ae5b