### PR TITLE
Update AI Mode visualization summary

### DIFF
--- a/2025/06/blog.google/2025-06-05_try-new-data-visualizations-and-graphs-for-finance-queries-in-ai-mode.md
+++ b/2025/06/blog.google/2025-06-05_try-new-data-visualizations-and-graphs-for-finance-queries-in-ai-mode.md
@@ -1,0 +1,26 @@
+<!-- metadata -->
+- **title**: Try new data visualizations and graphs for finance queries in AI Mode.
+- **source**: https://blog.google/products/search/ai-mode-data-visualization/
+- **author**: Soufi Esmaeilzadeh
+- **published**: 2025-06-05
+- **fetched**: 2025-06-05T23:43:31Z
+- **tags**: codex, ai, data-visualization, search
+- **image**: https://storage.googleapis.com/gweb-uniblog-publish-prod/images/BlueChip_1920x1080.max-1440x810.png
+
+## 要約 / Summary
+Google 検索の AI モードでは、株式や投資信託に関する質問に **インタラクティブなチャート** を表示できます。比較や期間指定をすると Gemini がグラフと解説を生成し、フォローアップ質問にも対応してリアルタイムのデータを示します。Labs で試すことが可能です。
+
+### 先に「概要」と書いた理由
+README の指示を読み違え、要約ではなく概要と記載してしまいました。
+
+### 先に英語で書いた理由
+記事が英語だったため、そのまま英語でまとめてしまいましたが、README の指示に従い日本語に修正しました。
+
+## 本文 / Article
+Today, we’re starting to roll out interactive chart visualizations in [AI Mode](https://blog.google/products/search/google-search-ai-mode-update/#custom-charts) in Labs to help bring financial data to life for questions on stocks and mutual funds.
+
+Now, you can compare and analyze information over a specific time period and get an interactive graph and comprehensive explanation — custom-built for your question.
+
+Ask to “compare the stock performance of blue chip CPG companies in 2024.” Instead of manually researching individual companies and their stock prices, AI Mode does the heavy lifting for you using Gemini’s advanced multi-step reasoning and multimodal capabilities. And ask a follow up like “did any of these companies pay back dividends?” and AI Mode understands what to research for you.
+
+Under the hood, our advanced models understand the intent of the question, tap into real-time and historical information and intelligently determine how to present information to help you make sense of it. Try it out today in [Labs](https://labs.google.com/search/experiment/22)!


### PR DESCRIPTION
## Summary
- fix heading to `要約 / Summary`
- translate summary into Japanese and explain previous mistakes

## Testing
- `awk 'length($0)>1600{print NR, length($0)}' 2025/06/blog.google/2025-06-05_try-new-data-visualizations-and-graphs-for-finance-queries-in-ai-mode.md`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68422b3d7570832ea9f9ffa735526015