### PR TITLE
Add clip: note.com article about Claude Code commands

### DIFF
--- a/2025/06/note.com/2025-06-09_n84d213738bbb.md
+++ b/2025/06/note.com/2025-06-09_n84d213738bbb.md
@@ -1,0 +1,73 @@
+<!-- metadata -->
+- **title**: Claude Codeのために福利厚生コマンドを入れよう｜Naoki |電電猫猫 
+- **source**: https://note.com/electrical_cat/n/n84d213738bbb
+- **author**: Naoki (電電猫猫)
+- **published**: 2025-06-09T12:02:00+09:00
+- **fetched**: 2025-06-09T08:50:39.731631+00:00
+- **tags**: codex, Claude, ripgrep
+- **image**: https://assets.st-note.com/production/uploads/images/195057132/rectangle_large_type_2_c574dd5efce5470f4770277cc41c76b2.png?fit=bounds&quality=85&width=1280
+
+## 要約
+この記事では、AIプログラミング支援ツールClaude Codeを快適に使うため、
+頻繁に使うripgrep、tree、ghと、必要に応じてjq、fd、batのインストールを勧めている。
+これらを入れておけばClaude Codeの環境が整い、日常の開発にも役立つと述べている。
+
+## 本文
+
+![見出し画像](https://assets.st-note.com/production/uploads/images/195057132/rectangle_large_type_2_c574dd5efce5470f4770277cc41c76b2.png?width=1200)  
+
+Claude Codeのために福利厚生コマンドを入れよう
+============================
+
+[![Naoki |電電猫猫 ](data:image/svg+xml;charset=utf8,%3Csvg%20viewBox%3D%220%200%20100%20100%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cdefs%3E%3ClinearGradient%20id%3D%22a%22%3E%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23f7f9f9%22%2F%3E%3Cstop%20offset%3D%2233%25%22%20stop-color%3D%22%23f7f9f9%22%2F%3E%3Cstop%20offset%3D%2250%25%22%20stop-color%3D%22%23fff%22%2F%3E%3Cstop%20offset%3D%2267%25%22%20stop-color%3D%22%23f7f9f9%22%2F%3E%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23f7f9f9%22%2F%3E%3CanimateTransform%20attributeName%3D%22gradientTransform%22%20type%3D%22translate%22%20from%3D%22-1%200%22%20to%3D%221%200%22%20begin%3D%220s%22%20dur%3D%221.5s%22%20repeatCount%3D%22indefinite%22%2F%3E%3C%2FlinearGradient%3E%3C%2Fdefs%3E%3Cpath%20class%3D%22rect%22%20fill%3D%22url(%23a)%22%20d%3D%22M-100-100h300v300h-300z%22%2F%3E%3C%2Fsvg%3E)](/electrical_cat)
+
+[Naoki |電電猫猫](/electrical_cat)
+
+2025年6月9日 12:02
+
+Claude Codeは普通にbashを扱うので，こいつが好きなコマンドを入れるといてあげるとClaude Codeの労働環境が良くなる．福利厚生だ．
+
+高頻度でClaude Codeが呼び出してるやつ
+
+```
+brew install ripgrep tree gh
+```
+
+たまに呼び出してるやつ
+
+```
+bashbrew install jq fd bat
+```
+
+以上！とりあえずClaude Code使うなら入れとこう．結構普通に使って便利だから普段使いしている人も多いでしょう．
+
+自分はripgrepは今回初めて入れました．
+
+ 
+
+ダウンロード
+
+ 
+
+copy
+
+いいなと思ったら応援しよう！
+--------------
+
+チップで応援する
+
+  
+
+* [#Claude](https://note.com/hashtag/Claude)
+* [#ripgrep](https://note.com/hashtag/ripgrep)
+
+ 
+
+[![Naoki |電電猫猫 ](data:image/svg+xml;charset=utf8,%3Csvg%20viewBox%3D%220%200%20100%20100%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cdefs%3E%3ClinearGradient%20id%3D%22a%22%3E%3Cstop%20offset%3D%220%25%22%20stop-color%3D%22%23f7f9f9%22%2F%3E%3Cstop%20offset%3D%2233%25%22%20stop-color%3D%22%23f7f9f9%22%2F%3E%3Cstop%20offset%3D%2250%25%22%20stop-color%3D%22%23fff%22%2F%3E%3Cstop%20offset%3D%2267%25%22%20stop-color%3D%22%23f7f9f9%22%2F%3E%3Cstop%20offset%3D%22100%25%22%20stop-color%3D%22%23f7f9f9%22%2F%3E%3CanimateTransform%20attributeName%3D%22gradientTransform%22%20type%3D%22translate%22%20from%3D%22-1%200%22%20to%3D%221%200%22%20begin%3D%220s%22%20dur%3D%221.5s%22%20repeatCount%3D%22indefinite%22%2F%3E%3C%2FlinearGradient%3E%3C%2Fdefs%3E%3Cpath%20class%3D%22rect%22%20fill%3D%22url(%23a)%22%20d%3D%22M-100-100h300v300h-300z%22%2F%3E%3C%2Fsvg%3E)](/electrical_cat)
+
+[Naoki |電電猫猫](/electrical_cat)
+
+フォロー
+
+22歳iOSエンジニア．早稲田大学数学科3年生．休学2年して復学。
+プログラミングと回路、自作キーボードと、たまに数学とか。


### PR DESCRIPTION
## Summary
- add clipping for note.com article about Claude Code command installation
- include summary in Japanese and relevant metadata

## Testing
- `python -m py_compile pdf_to_text.py scrape.py`


------
https://chatgpt.com/codex/tasks/task_e_6846a0339384832e8126ecf39cce82cf