### PR TITLE
Add clip: Next.js MCP setup

### DIFF
--- a/2025/06/qiita.com/2025-06-09_445db2d542f44f9a3e4c.md
+++ b/2025/06/qiita.com/2025-06-09_445db2d542f44f9a3e4c.md
@@ -1,0 +1,457 @@
+<!-- metadata -->
+- **title**: Next.js + Mastra環境でMCPを使うのは難しい。。 - Qiita
+- **source**: https://qiita.com/moritalous/items/445db2d542f44f9a3e4c
+- **author**: qiita.com
+- **published**: 
+- **fetched**: 2025-06-09T08:55:45.394915+00:00
+- **tags**: codex, mcp, next.js, bedrock, playwright, mastra
+- **image**: https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-user-contents.imgix.net%2Fhttps%253A%252F%252Fcdn.qiita.com%252Fassets%252Fpublic%252Farticle-ogp-background-afbab5eb44e0b055cce1258705637a91.png%3Fixlib%3Drb-4.0.0%26w%3D1200%26blend64%3DaHR0cHM6Ly9xaWl0YS11c2VyLXByb2ZpbGUtaW1hZ2VzLmltZ2l4Lm5ldC9odHRwcyUzQSUyRiUyRnMzLWFwLW5vcnRoZWFzdC0xLmFtYXpvbmF3cy5jb20lMkZxaWl0YS1pbWFnZS1zdG9yZSUyRjAlMkY0MTU3NCUyRjRlZjYzODMyOTNiYTllNmNlZmJiOThmYzhjNjViZDRjZjZjYjM4YTIlMkZ4X2xhcmdlLnBuZyUzRjE1OTU2NDI5ODU_aXhsaWI9cmItNC4wLjAmYXI9MSUzQTEmZml0PWNyb3AmbWFzaz1lbGxpcHNlJmZtPXBuZzMyJnM9ZTFlNGUwZGIzYzk1NWIxYjQxY2VjZjJkNGFmZDI5ZWM%26blend-x%3D120%26blend-y%3D467%26blend-w%3D82%26blend-h%3D82%26blend-mode%3Dnormal%26s%3Dde1fbbe710093376a1e4ee9e4ec36763?ixlib=rb-4.0.0&w=1200&fm=jpg&mark64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTk2MCZoPTMyNCZ0eHQ9TmV4dC5qcyUyMCUyQiUyME1hc3RyYSVFNyU5MiVCMCVFNSVBMiU4MyVFMyU4MSVBN01DUCVFMyU4MiU5MiVFNCVCRCVCRiVFMyU4MSU4NiVFMyU4MSVBRSVFMyU4MSVBRiVFOSU5QiVBMyVFMyU4MSU5NyVFMyU4MSU4NCVFMyU4MCU4MiVFMyU4MCU4MiZ0eHQtYWxpZ249bGVmdCUyQ3RvcCZ0eHQtY29sb3I9JTIzMUUyMTIxJnR4dC1mb250PUhpcmFnaW5vJTIwU2FucyUyMFc2JnR4dC1zaXplPTU2JnR4dC1wYWQ9MCZzPWI5ZGQ0MTE3NTg3ZmVkMjNlNGEyNzYyMmJiMmNmZDRj&mark-x=120&mark-y=112&blend64=aHR0cHM6Ly9xaWl0YS11c2VyLWNvbnRlbnRzLmltZ2l4Lm5ldC9-dGV4dD9peGxpYj1yYi00LjAuMCZ3PTgzOCZoPTU4JnR4dD0lNDBtb3JpdGFsb3VzJnR4dC1jb2xvcj0lMjMxRTIxMjEmdHh0LWZvbnQ9SGlyYWdpbm8lMjBTYW5zJTIwVzYmdHh0LXNpemU9MzYmdHh0LXBhZD0wJnM9NTE5MDJlZTJlOTExNTEzZmVhMTBjNzY4YjZmNjRkM2I&blend-x=242&blend-y=480&blend-w=838&blend-h=46&blend-fit=crop&blend-crop=left%2Cbottom&blend-mode=normal&s=f44753c3a8ad449abdce08587a6eeccf
+
+## 要約
+
+MastraとMCP(Playwright連携ツール)をNext.jsで使うと、ツールが共有されブラウザ状態が他ユーザーに漏れる。公式例は単一ユーザー向けで、マルチユーザー環境では各リクエスト毎にID付きのMCPClientを初期化し、ストリーム終了や中断時にdisconnect()を呼び出す実装に改めることで情報漏えいを防げる。
+
+## 本文
+
+[![](https://qiita-user-profile-images.imgix.net/https%3A%2F%2Fs3-ap-northeast-1.amazonaws.com%2Fqiita-image-store%2F0%2F41574%2F4ef6383293ba9e6cefbb98fc8c65bd4cf6cb38a2%2Fx_large.png%3F1595642985?ixlib=rb-4.0.0&auto=compress%2Cformat&lossless=0&w=48&s=9e1f48e63c0cf58dfc3e42261ec49aa4)
+
+@moritalous](/moritalous)
+
+Next.js + Mastra環境でMCPを使うのは難しい。。
+================================
+
+* [MCP](/tags/mcp)
+* [Next.js](/tags/next.js)
+* [bedrock](/tags/bedrock)
+* [Playwright](/tags/playwright)
+* [Mastra](/tags/mastra)
+
+Posted at 2025-06-09
+
+MastraとMCP、ナウいコンビで最高ですね！
+
+ドキュメントを参考に作ると、多分こんな感じになると思います。（私だけだったらごめんなさい）
+
+tree
+
+```
+app
+├── api
+│   └── chat
+│       └── route.ts
+├── layout.tsx
+└── page.tsx
+mastra
+├── agents
+│   └── index.ts
+├── index.ts
+└── tools
+    └── index.ts
+
+6 directories, 6 files
+
+```
+
+* `mastra`ディレクトリ
+
+  MCPツールとして、ナウいPlaywrightを選択！
+
+  mastra/tools/index.ts
+
+  ```
+  import { MCPClient } from "@mastra/mcp";
+
+  export const mcp = new MCPClient({
+    servers: {
+      playwright: {
+        command: "docker",
+        args: ["run", "-i", "--rm", "--init", "mcr.microsoft.com/playwright/mcp"],
+      },
+    },
+  });
+
+  ```
+
+  mastra/agents/index.ts
+
+  ```
+  import { mcp } from "@/mastra/tools";
+  import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
+  import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
+  import { Agent } from "@mastra/core/agent";
+
+  const bedrock = createAmazonBedrock({
+    region: "ap-northeast-1",
+    credentialProvider: fromNodeProviderChain(),
+  });
+
+  export const myAgent = new Agent({
+    name: "My Agent",
+    instructions: "You are a helpful assistant.",
+    model: bedrock("apac.amazon.nova-pro-v1:0"),
+    tools: await mcp.getTools(),
+  });
+
+  ```
+
+  mastra/index.ts
+
+  ```
+  import { Mastra } from "@mastra/core";
+  import { myAgent } from "./agents";
+
+  export const mastra = new Mastra({
+    agents: { myAgent },
+  });
+
+  ```
+* `app`ディレクトリ
+
+  app/api/chat/route.ts
+
+  ```
+  import { mastra } from "@/mastra";
+
+  // Allow streaming responses up to 30 seconds
+  export const maxDuration = 30;
+
+  export async function POST(req: Request) {
+    const { messages } = await req.json();
+
+    const myAgent = mastra.getAgent("myAgent");
+
+    const result = await myAgent.stream(messages);
+
+    return result.toDataStreamResponse();
+  }
+
+  ```
+
+  app/page.tsx
+
+  ```
+  'use client';
+
+  import { useChat } from '@ai-sdk/react';
+
+  export default function Chat() {
+    const { messages, input, handleInputChange, handleSubmit } = useChat();
+    return (
+      <div className="flex flex-col w-full max-w-md py-24 mx-auto stretch">
+        {messages.map(message => (
+          <div key={message.id} className="whitespace-pre-wrap">
+            {message.role === 'user' ? 'User: ' : 'AI: '}
+            {message.parts.map((part, i) => {
+              switch (part.type) {
+                case 'text':
+                  return <div key={`${message.id}-${i}`}>{part.text}</div>;
+              }
+            })}
+          </div>
+        ))}
+
+        <form onSubmit={handleSubmit}>
+          <input
+            className="fixed dark:bg-zinc-900 bottom-0 w-full max-w-md p-2 mb-8 border border-zinc-300 dark:border-zinc-800 rounded shadow-xl"
+            value={input}
+            placeholder="Say something..."
+            onChange={handleInputChange}
+          />
+        </form>
+      </div>
+    );
+  }
+
+  ```
+
+完成したので、動作確認です
+
+> playwright MCPツールで、Yahoo.co.jpにアクセスし、今日の主要ニュースを調べて。  
+> １つ目のURLにアクセスし、ニュースの詳細を教えて下さい。
+
+トップページを表示した後にリンクをクリックして次のページを取得してくれました。
+
+[![image.png](https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F41574%2Fdcf63bf4-ae58-455d-87ae-8856fb1dc067.png?ixlib=rb-4.0.0&auto=format&gif-q=60&q=75&s=ea25d0223a0cc7ca941b2026c770ffc1)](https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F41574%2Fdcf63bf4-ae58-455d-87ae-8856fb1dc067.png?ixlib=rb-4.0.0&auto=format&gif-q=60&q=75&s=ea25d0223a0cc7ca941b2026c770ffc1)
+
+Playwright、マジ最高。
+
+そしてここでおもむろに別のブラウザ（下図の右側）を立ち上げて
+
+> 最後にアクセスしたURLを教えて下さい。
+
+と聞くと
+
+[![image.png](https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F41574%2F49453082-5f33-4849-9d6c-939e181d0136.png?ixlib=rb-4.0.0&auto=format&gif-q=60&q=75&s=baa978225f8592bf23b3419d4ead8041)](https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F41574%2F49453082-5f33-4849-9d6c-939e181d0136.png?ixlib=rb-4.0.0&auto=format&gif-q=60&q=75&s=baa978225f8592bf23b3419d4ead8041)
+
+なんということでしょう！
+
+**先ほど別ブラウザ（＝別人）でアクセスしたURLが取得できたではありませんか！！！**
+
+これは良くない、良くない、良くない。恥ずかしい。
+
+---
+
+ということで、この問題への対策の件です。
+
+これまで私が書いた記事を参考にしてくれた方、ごめんなさい。間違った実装を提示してたと思います。
+
+種明かし
+----
+
+実はドキュメントに記載があります。ちょっと前はなかった気がします。
+
+[![mastra.ai_en_docs_tools-mcp_mcp-overview.png](https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F41574%2Fde987003-cbdd-416b-89a5-d723e7e2c83e.png?ixlib=rb-4.0.0&auto=format&gif-q=60&q=75&s=e317a0011693f94b4f34ceb5c19120a4)](https://qiita-user-contents.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F41574%2Fde987003-cbdd-416b-89a5-d723e7e2c83e.png?ixlib=rb-4.0.0&auto=format&gif-q=60&q=75&s=e317a0011693f94b4f34ceb5c19120a4)
+
+シングルユーザー利用を想定した「Static Configuration」と、マルチユーザー利用を想定した「Dynamic Configuration」があるのですね。
+
+上で紹介した方法は、シングルユーザー向けの実装でしたので、マルチユーザー利用のクライアント・サーバー型では問題が起きてましたということです。
+
+実装をダイナミックに更新
+------------
+
+ツールをエージェントに事前セットするのではなく、ツール実行のタイミングで初期化してエージェントへセットする実装に変更します。
+
+こうなります。
+
+* `mastra/tools/index.ts`  
+  不要なので削除します
+* `mastra/agents/index.ts`  
+  エージェントの定義にツールを含めません
+
+  mastra/agents/index.ts
+
+  ```
+  - import { mcp } from "@/mastra/tools";
+    import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock";
+    import { fromNodeProviderChain } from "@aws-sdk/credential-providers";
+    import { Agent } from "@mastra/core/agent";
+    
+    const bedrock = createAmazonBedrock({
+      region: "ap-northeast-1",
+      credentialProvider: fromNodeProviderChain(),
+    });
+    
+    export const myAgent = new Agent({
+      name: "My Agent",
+      instructions: "You are a helpful assistant.",
+      model: bedrock("apac.amazon.nova-pro-v1:0"),
+  -   tools: await mcp.getTools(),
+    });
+
+  ```
+* `mastra/index.ts`  
+  変更ありません
+* `app/api/chat/route.ts`  
+  APIが呼ばれるタイミングでMCPツールを初期化します。 **これで、複数のリクエストでツールが使い回されることがありません**  
+  （ただし、複数の会話ターンで前回のツールを引き継ぐということはできません）
+
+app/api/chat/route.ts
+
+```
+  import { mastra } from "@/mastra";
++ import { MCPClient } from "@mastra/mcp";
+  
+  // Allow streaming responses up to 30 seconds
+  export const maxDuration = 30;
+  
+  export async function POST(req: Request) {
++   const mcp = new MCPClient({
++     servers: {
++       playwright: {
++         command: "docker",
++         args: [
++           "run",
++           "-i",
++           "--rm",
++           "--init",
++           "mcr.microsoft.com/playwright/mcp",
++         ],
++       },
++     },
++   });
+  
+    const { messages } = await req.json();
+  
+    const myAgent = mastra.getAgent("myAgent");
+
+-   const result = await myAgent.stream(messages);
++   const result = await myAgent.stream(messages, {
++     toolsets: await mcp.getToolsets(),
++   });
+  
+    return result.toDataStreamResponse();
+  }
+
+```
+
+上記ではまだ問題があります。リクエストのたびにMCPサーバーへ接続するのですが、切断処理が入っていません。  
+`mcp.disconnect()`を呼び出す必要があるのですが、これが曲者です。
+
+ストリームで返却する都合上、returnの後ろに処理をかけません。  
+そのため、try～finallyしてみたのですが、動作上はストリームが終わる前の早い段階でクローズされてしまい、MCPツールが正しく呼べませんでした。
+
+app/api/chat/route.ts（うまくいかない実装）
+
+```
+try{
+    return result.toDataStreamResponse();
+} finally {
+    mcp.disconnect()
+}
+
+```
+
+そこで、Amazon Q Developer CLIに実装してもらったのがこちらです。
+
+期待動作をしましたが、コードの意味は聞かないでください（笑）
+
+app/api/chat/route.ts（うまく動作した実装）
+
+```
+import { mastra } from "@/mastra";
+import { MCPClient } from "@mastra/mcp";
+
+// Allow streaming responses up to 30 seconds
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  // 各リクエストで独立したMCPClientを作成（ユニークなIDを使用）
+  const requestId = `mcp-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  const mcp = new MCPClient({
+    id: requestId, // メモリリーク防止のためのユニークID
+    servers: {
+      playwright: {
+        command: "docker",
+        args: [
+          "run",
+          "-i",
+          "--rm",
+          "--init",
+          "mcr.microsoft.com/playwright/mcp",
+        ],
+      },
+    },
+  });
+
+  // クリーンアップ関数
+  const cleanup = async () => {
+    try {
+      await mcp.disconnect();
+      console.log(`MCP Client ${requestId} disconnected`);
+    } catch (error) {
+      console.error(`Error disconnecting MCP Client ${requestId}:`, error);
+    }
+  };
+
+  // リクエストがキャンセルされた場合のクリーンアップ
+  req.signal?.addEventListener('abort', () => {
+    console.log(`Request ${requestId} aborted, cleaning up...`);
+    cleanup();
+  });
+
+  try {
+    const { messages } = await req.json();
+    const myAgent = mastra.getAgent("myAgent");
+
+    const result = await myAgent.stream(messages, {
+      toolsets: await mcp.getToolsets(),
+    });
+
+    // ストリーミングレスポンスを取得
+    const response = result.toDataStreamResponse();
+    
+    // レスポンスのbodyストリームをラップして、完了時にクリーンアップを実行
+    const originalBody = response.body;
+    if (originalBody) {
+      let cleanupCalled = false;
+      
+      const safeCleanup = async () => {
+        if (!cleanupCalled) {
+          cleanupCalled = true;
+          await cleanup();
+        }
+      };
+
+      const wrappedStream = new ReadableStream({
+        start(controller) {
+          const reader = originalBody.getReader();
+          
+          const pump = async () => {
+            try {
+              while (true) {
+                const { done, value } = await reader.read();
+                
+                if (done) {
+                  controller.close();
+                  // ストリーム完了時にクリーンアップ
+                  await safeCleanup();
+                  break;
+                }
+                
+                controller.enqueue(value);
+              }
+            } catch (error) {
+              controller.error(error);
+              // エラー時もクリーンアップ
+              await safeCleanup();
+            }
+          };
+          
+          pump();
+        },
+        cancel() {
+          // ストリームがキャンセルされた時もクリーンアップ
+          safeCleanup();
+        }
+      });
+
+      // 新しいレスポンスを作成
+      return new Response(wrappedStream, {
+        headers: response.headers,
+        status: response.status,
+        statusText: response.statusText,
+      });
+    }
+
+    // bodyがない場合は元のレスポンスを返してクリーンアップ
+    await cleanup();
+    return response;
+
+  } catch (error) {
+    console.error("Error in chat2 API:", error);
+    // エラー時もクリーンアップ
+    await cleanup();
+    
+    return new Response(
+      JSON.stringify({ error: "Internal server error" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+}
+
+```
+
+外部検索とか、ステートレスなツールであれば影響なさそうですが、ツールによっては問題があるよというお話でした。
+
+[4](/moritalous/items/445db2d542f44f9a3e4c/likers)
+
+Go to list of users who liked
+
+1
+
+[comment0](#comments)
+
+Go to list of comments
+
+Register as a new user and use Qiita more conveniently
+
+1. You get articles that match your needs
+2. You can efficiently read back useful information
+3. You can use dark theme
+
+[What you can do with signing up](https://help.qiita.com/ja/articles/qiita-login-user)
+
+[Sign up](/signup?callback_action=login_or_signup&redirect_to=%2Fmoritalous%2Fitems%2F445db2d542f44f9a3e4c&realm=qiita)[Login](/login?callback_action=login_or_signup&redirect_to=%2Fmoritalous%2Fitems%2F445db2d542f44f9a3e4c&realm=qiita)


### PR DESCRIPTION
## Summary
- scrape Qiita article on using MCP with Next.js/Mastra
- add Japanese summary for avoiding shared MCP clients by instantiating MCPClient per request and disconnecting properly

## Testing
- `python3 scrape.py https://qiita.com/moritalous/items/445db2d542f44f9a3e4c`


------
https://chatgpt.com/codex/tasks/task_e_6846a14b9964832e9f51455c1f4c63c0