### PR TITLE
Add clip: scaling laws for open vision models

### DIFF
--- a/2025/06/arxiv.org/2025-06-05_scaling-laws-for-robust-comparison-of-open-foundation-language-vision-models-and-datasets.md
+++ b/2025/06/arxiv.org/2025-06-05_scaling-laws-for-robust-comparison-of-open-foundation-language-vision-models-and-datasets.md
@@ -1,0 +1,1556 @@
+<!-- metadata -->
+- **title**: Scaling Laws for Robust Comparison of Open Foundation Language-Vision Models and Datasets
+- **source**: https://arxiv.org/abs/2506.04598
+- **author**: Marianna Nezhurina et al.
+- **published**: 2025-06-05
+- **fetched**: 2025-06-09T21:54:01Z
+- **tags**: codex, scaling-laws, language-vision
+- **image**: /static/browse/0.3.4/images/arxiv-logo-fb.png
+
+## 要約
+オープンデータセット上でCLIPとMaMMUTを訓練し、密なスケール測定から得られるスケーリング則を用いてモデルとデータセットを比較する手法を提示する。小規模計算ではCLIPが優位だが、計算量が増えるとMaMMUTが優位となり、約10^10～10^11 GFLOPSで両者の性能が逆転することを明らかにした。DataComp、DFN、Re-LAIONという三つのデータセットで同様の傾向が確認され、特にDFNが分類と検索の両面で最も高いスケーラビリティを示す。さらに、一定学習率スケジュールでも98%の計算削減で同様の結論を得られることを示し、スケーリング則に基づく比較が少数のスケールだけから得られる誤解を避ける上で有用であると結論づけている。すべての中間チェックポイントとopenMaMMUT-L/14モデルを公開し、再現性のあるオープンな基盤モデルの構築を促進する。
+
+## 本文
+arXiv:2506.04598v1  [cs.LG]  5 Jun 2025Scaling Laws for Robust Comparison of Open
+Foundation Language-Vision Models and Datasets
+Marianna Nezhurina1,2,5§∗Tomer Porian1,2,5∗Giovanni Pucceti3Tommie Kerssies1,4
+Romain Beaumont1Mehdi Cherti1,2,5§°∗Jenia Jitsev1,2,5°∗
+1LAION2Juelich Supercomputing Center (JSC), Research Center Juelich (FZJ)
+3Institute of Information Science and Technologies “A. Faedo” - CNR Pisa
+4Eindhoven University of Technology
+5Open- Ψ(Open-Sci) Collective
+§ equal first, °equal senior,∗core contribution
+{m.nezhurina,m.cherti,j.jitsev}@fz-juelich.de,contact@laion.ai
+Abstract
+In studies of transferable learning, scaling laws are obtained for various important
+foundation models to predict their properties and performance at larger scales.
+We show here how scaling law derivation can also be used for model and dataset
+comparison, allowing to decide which procedure is to be preferred for pre-training.
+For the first time, full scaling laws based on dense measurements across a wide
+span of model and samples seen scales are derived for two important language-
+vision learning procedures, CLIP and MaMMUT, that use either contrastive only
+or contrastive and captioning text generative loss. Ensuring sufficient prediction
+accuracy for held out points, we use derived scaling laws to compare both models,
+obtaining evidence for MaMMUT’s stronger improvement with scale and better
+sample efficiency than standard CLIP. To strengthen validity of the comparison,
+we show scaling laws for various downstream tasks, classification, retrieval, and
+segmentation, and for different open datasets, DataComp, DFN and Re-LAION,
+observing consistently the same trends. We show that comparison can also be
+performed when deriving scaling laws with a constant learning rate schedule,
+reducing compute cost. Accurate derivation of scaling laws provides thus means
+to perform model and dataset comparison across scale spans, avoiding misleading
+conclusions based on measurements from single reference scales only, paving
+the road for systematic comparison and improvement of open foundation models
+and datasets for their creation. We release all the pre-trained models with their
+intermediate checkpoints, including openMaMMUT-L/14, which achieves 80.3%
+zero-shot ImageNet-1k accuracy, trained on 12.8B samples from DataComp-1.4B1.
+1 Introduction
+Foundation models [ 1] pre-trained on generic, diverse large datasets enabled massive improvements
+in transfer learning, showing strong and efficient adaptability across a wide range of downstream
+tasks not shown during pre-training. Thanks to learning procedures leading to foundation models,
+transferable learning can be studied across various important domains, including language [ 2,3,4],
+vision [5], language-audio [6], and language-vision [7].
+Progress in improving learning procedures leading to stronger foundation models crucially depends
+on the ability to perform systematic and consistent learning procedure comparison. Usually, following
+1Code for reproducing experiments in the paper and raw experiments data can be found in the repository
+Preprint. Under review.
+the training, various foundation models are compared via performance shown on a wide range of
+standardized reference downstream tasks. Often, this comparison is done on only one or few selected
+reference model and data scales, without carefully aligning the compute put into pre-training. Further,
+important parts of learning procedure like training dataset often remain closed. This makes it hard or
+impossible to discern whether the observed model differences are due to algorithmic, dataset or due
+to differences in pre-training compute, or a combination of them, leaving also unclear whether the
+comparison holds for other scales than the few selected ones.
+In our work, we make a step towards resolving these issues by using scaling law derivation to enable
+systematic training procedure, model, and dataset comparison. Foundation models exhibit scaling
+laws [ 8,9,10,11] that allow to determine dependence of model properties and performance on total
+pre-training compute from measurements on smaller scales, enabling predictions across a wide scale
+span instead of only one or few selected points. Here, we show how using open datasets for scaling
+law derivation can enable model and dataset comparison that takes into account model behavior
+across a wide range of pre-training compute budgets and across different downstream tasks, while
+offering full control over variations in the whole training pipeline, and being fully reproducible.
+We choose language-vision learning as an important setting for model and dataset comparison using
+scaling law derivation. Contrastive language-image pre-training (CLIP) [ 7] is a well-established
+learning procedure resulting in models that show impressive robustness and transfer capability, and are
+used routinely as pre-trained components in many setups such as vision-language instruction tuning
+models (LLaVa [ 12], InternVL [ 13], SigLIP [ 14]) and text to image generation models [ 15]. Since
+the first release of CLIP, many extensions have been proposed such as CoCa [ 16], MaMMUT [ 17],
+and SigLIP [ 18,14]. These works claim more performant language-vision models than standard
+CLIP. However, as hinted above, it is still unclear which of the training procedures are better for
+what reasons, and whether claims of improving on the standard CLIP procedure hold across scales.
+Here, we conduct a large-scale study of the scaling laws of two important procedures, namely CLIP
+and MaMMUT, pre-trained on open reference datasets, DataComp-1.4B [ 19], DFN-1.4B [ 20] and
+Re-LAION-1.4B [ 21], which we are able to compare via full scaling law derivation for the first time.
+Our study reveals that while CLIP has advantage on smaller compute scales, MaMMUT architecture
+shows advantage as we increase compute, as illustrated by a line crossing of the scaling curves in Fig.
+1, 2,3 (Sec. 3.1). Importantly, we find that the result is consistent and robust across the pre-training
+datasets, learning schedules and the downstream tasks used for measuring the error performance,
+which covers zero-shot classification, retrieval, and segmentation. Training on DataComp-1.4B leads
+to stronger scalability on classification, but no difference on retrieval versus Re-LAION-1.4B, while
+training on DFN-1.4B outperforms DataComp and Re-LAION on both classification and retrieval for
+both tested CLIP and MaMMUT models (Sec. 3.2). We make the results fully reproducible by using
+open training datasets, open-source training code for both CLIP and MaMMUT, and by providing
+fully detailed procedure and code for scaling laws derivation.
+Our Contributions. 1) We conduct first large-scale study of CLIP [ 7,10] and MaMMUT [ 17]
+with dense measurements to ensure better prediction to unseen scales and valid model and dataset
+comparison. Measurements cover model sizes from S/32 to H/14, samples seen from 1.28M to
+3B, on both DataComp-1.4B [ 19] and Re-LAION-1.4B [ 21] datasets (model sizes up to L/14 and
+samples seen up to 300M on DFN-1.4B [ 20]) and evaluating downstream performance on tasks
+covering zero-shot classification, retrieval, and segmentation. 2)Based on derived scaling laws, we
+perform model and dataset comparison. We show validity of this comparison by revealing consistent
+trends in favor of MaMMUT versus CLIP architecture across different downstream tasks, open
+datasets Re-LAION-1.4B, DataComp-1.4B and DFN-1.4B (while also showing consistent trends
+favoring DFN over other datasets), and scaling law types (compute-optimal and samples seen based
+scaling laws). Our study is thus the first to provide a fully reproducible systematic comparison of
+important open foundation models openCLIP and openMaMMUT and important reference open
+datasets Re-LAION-1.4B, DataComp-1.4B and DFN-1.4B. 3)We perform the study using both
+cosine and constant learning rate schedules, and observe the same consistent trends, revealing that the
+scaling laws based comparison can be also performed with suboptimal constant learning rate schedule
+resulting in 98% less compute cost. 4). We provide a detailed procedure to fit scaling laws tailored for
+model and dataset comparison, sharing our findings on best practices of scaling law derivation which
+include uncertainty quantification and measuring held-out points on the compute or samples-seen
+axis. 5)We make our study fully reproducible and release all the intermediate checkpoints from
+scaling law derivation experiments. For the first time, we provide an open-source implementation of
+2
+MaMMUT, openMaMMUT, and release openMaMMUT-L/14 trained on 12.8B image-text samples
+from an open dataset DataComp-1.4B, achieving 80.3% zero-shot ImageNet-1k accuracy.
+2 Methods & experimental setup
+Our experiments entail model pre-training, evaluation and scaling law derivation, which we describe
+in the following.
+2.1 Pre-training setup
+Architecture details . The MaMMUT model is integrated into the openCLIP code base [ 22] to
+take advantage of the existing implementation of the CLIP contrastive loss and CoCa captioning
+loss. Key additions to implement MaMMUT were: (1) using a double forward pass for the text
+component to perform both text encoding (without masking) and decoding (with causal masking); (2)
+cross-attention between image and text tokens. For an N-layer text decoder, cross-attention layers are
+inserted every 2 text decoder layers [17], resulting in a total of [N
+2]cross-attention layers.
+Training dataset & objective . We pre-trained CLIP and MaMMUT models on DataComp-1.4B [ 19],
+Re-LAION-1.4B [ 21] and DFN-1.4B [ 20] datasets. Re-LAION-1.4B was obtained by downloading
+theRe-LAION-2B-en-research subset of Re-LAION [ 21] which contained ≈30% dead links,
+resulting in a total of 1.4B image-caption pairs. DFN-1.4B was obtained by downloading DFN-2B
+dataset [ 20], which also resulted in discovering ≈30% link rot, again providing 1.4B image-text
+pairs in total. CLIP models are trained with contrastive InfoNCE [ 23] loss ( L=Lcontrastive ), while
+MaMMUT models are trained with contrastive and captioning losses ( L=Lcontrastive +λLcap), we
+usedλ= 1in our experiments.
+Model & samples seen scales . For both CLIP and MaMMUT architectures, we consider
+ViT-S, ViT-M, ViT-B, ViT-L, and ViT-H as vision encoders. For each vision encoder size,
+we also vary patch size, and consider patch sizes of 32x32, 16x16, and 14x14, leading to
+|M|= 15 model configurations. We scale text encoders accordingly following previous lit-
+erature [ 10]. For samples seen scales D, we consider a wide range of measurements D=
+{1.28M,3.07M,6.4M,12.8M,30.7M,64M,128M,307M,640M,1.28B,3.07B}, a total of |D|=
+11configurations. See App. Tab. 12 for full details about models and number of samples we used in
+our experiments.
+Learning rate schedule . In our experiments, we consider both cosine and constant learning rate
+schedulers. For cosine learning rate schedule experiments, we performed a single run for each
+model-samples seen pair, while for constant learning rate schedule, we only need to train once for
+each model size.
+Optimization . We additionally perform a hyper-parameter sweep for batch size, learning rate and
+warmup for each training run to avoid suboptimal solutions. We have observed that it is important,
+especially in small sample seen scales, as large batch sizes usually used in CLIP training will result
+in small number of optimization steps, making optimization suboptimal. For training, we used
+AdamW [ 24] as an optimizer with a weight decay of 0.2. To avoid unstable training and loss spikes
+with larger models (e.g., ViT-L, ViT-H) we followed [ 10,25] and used β1= 0.9,β2= 0.95, gradient
+clip norm of 1, warmup and mixed precision with bfloat16 . See more details in App. Tab. 10, 11.
+2.2 Downstream evaluation
+Zero-shot classification . We evaluate the top-1 zero-shot accuracy on 35 classification tasks from the
+DataComp evaluation suite [ 19]. It includes ImageNet-1k [ 26], ImageNet robustness to distribution
+shift datasets [ 27,28,29,30,31], and additional 29 classification tasks covering multiple domains.
+We follow the evaluation protocol of [ 10], i.e. using the same prompts, class names, and code
+base [ 32]. The full list of datasets we used in evaluation with description is included in App. Sec. 3.5.
+Zero-shot retrieval . We evaluate models on MS-COCO[ 33] image and text retrieval Recall@5
+metrics, following [10].
+Segmentation . We fine-tune for semantic segmentation on ADE20K [ 34], following [ 35], using 31
+epochs and a 1500-step warmup [36], with a consistent 224×224input and 14×14patch size.
+3
+2.3 Scaling law derivation and fitting procedure
+We vary both model architecture size (number of parameters of both text and vision towers), number
+of samples seen and patch size. In general, the relationship between compute and performance
+follows a power law: L=aCb, where Cis compute in FLOPs [ 10,37] and C= arg min L(C).
+Since we use error rate on ImageNet-1k zero-shot classification, we follow [ 37,38] and take into
+account the saturation ( Bc) that occurs at the small compute scales due to the nature of classification
+tasks - the probability of predicting a class even at zero-compute is determined by the frequency
+of this class in the test set. On the other hand, tasks like zero-shot image classification cannot be
+solved with 100% accuracy due to task- and learning method-intrinsic performance ceiling [38, 37].
+Accordingly, we require that our scaling law functional form satisfies:
+L(C)>0(strictly positive) ,lim
+C→∞L(C) =E(irreducible error) ,dL
+dC<0(monotonic decrease).
+Given above criteria, we obtain the following functional form for the error that satisfies all three
+(subscript Cspecifies compute dependency):
+L(C) =Ac·(C+Bc)−αc+Ec, αc>0 (1)
+For each combination of compute scale Cand model architecture, we take a point with the minimal
+error rate. In previous works [ 39], points with minimal loss were found by binning FLOP values
+into 1500 FLOP logarithmically spaced intervals. We use the same approach to find points with
+minimal error. Therefore, we obtain a mapping from each combination of number of parameters N
+and samples seen Dto the compute C(in GFLOPs).
+Using measurements {(Ci, Yi)}where Ciis compute budget (GFLOPs) and Yiis error performance,
+we fit the curve only on points with compute budget below a threshold { (Ci, Yi), Ci< C threshold }.
+To quantify the quality of our fit, we use mean squared error on the remaining (held-out) points:
+MSE =1
+nP
+i:Ci≥Cthreshold(L(Ci)−Yi)2.
+2.4 Confidence intervals estimation
+We compute 95% confidence intervals for the estimates of the model downstream task performance
+by propagating the uncertainty from the estimated scaling law fit parameters. We compute the
+Jacobian of the scaling law fit, J, with respect to the fit parameters at the extrapolated points. We
+then estimate the variance of our predictions as σ2=J⊤Cov(ˆθ)J. Confidence intervals are then
+given by ˆy±tα/2, n−p·σ, where tα/2, n−pis the critical value from the Student’s t-distribution at
+α= 0.05.
+2.5 Data efficiency and optimal dataset size estimation
+To quantify the data efficiency of CLIP and MaMMUT, we fit a scaling law analogous to Equation 1:
+L(D) =AD·(D+BD)−αD+ED (2)
+Here,L(D)denotes the expected error rate as a function of the number of samples seen D. For
+each unique data budget D, we extract the corresponding minimal error points {D,L(D)}using the
+Skyline Operator algorithm [40], which selects non-dominated configurations based on error rate.
+To estimate the dataset size that is optimal for a given compute budget, we follow the approach of [ 9]
+and fit a power-law relationship of the form: Dopt=D0·Ca, where Doptminimizes L(C, D)for
+a given compute budget C. The optimal dataset sizes are obtained by identifying (C, D)pairs that
+yield minimal error rate under fixed compute constraints.
+3 Results
+3.1 Scaling laws for model comparison
+We fit function that has a form of eq. 1 on the obtained experimental data using methods described
+in Section 2.3. To avoid the confound of data repetition [ 41] we limit the data used for our scaling
+4
+law fits by selecting only models that were trained on up to 3B. In Tab. 5a estimated parameters
+for both models (CLIP and MaMMUT) as well as for both downstream tasks (IN1k classification
+and MS-COCO retrieval) can be found. MaMMUT consistently exhibits better scaling behaviour
+compared to CLIP. This is reflected in smaller error rates at equivalent compute budget at larger scales
+after crossing a compute threshold that is consistently found to be between 1010and1011GFLOPS
+across various datasets (Fig. 1, 2,3). This indicates better efficiency and generalization as we increase
+compute. Moreover, this trend holds across:
+•Pre-training datasets: DataComp-1.4B (Fig. 1), Re-LAION-1.4B (Fig. 2) and DFN-1.4B
+(Fig. 3).
+•Downstream tasks: ImageNet-1k zero-shot image classification (see Fig. 1 (a), Fig. 2 (a),
+Fig. 3 (a)) and MS-COCO image retrieval (Fig. 1 (b), Fig. 2 (b), Fig. 3 (b)), ADE20K
+semantic segmentation (Fig. 13).
+• Learning rate scheduler: cosine (Fig. 1) and constant (Fig. 14).
+Note that on smaller scales in the lower performance range, CLIP consistently outperforms MaMMUT,
+which then consistently takes over CLIP at larger compute scales in the higher performance range.
+We validate our fits by fitting the laws only up to certain compute budgets Cthreshold and then extrapo-
+lating to larger ones. We use these extrapolated points to compute MSE, which allows us to check on
+quality of the obtained fits, observing that adding more points to the fit reduces MSE on held-out
+points and also reduces uncertainty of predictions. Detailed versions of scaling laws plots for CLIP
+and MaMMUT can be found in Appendix B, more details on validating fit quality are in Appendix C.
+As further evidence for the validity of derived scaling laws, we observe same consistent scalability
+trends across datasets and on further important downstream tasks, for instance on DataComp eval
+suite (Fig. 11), ImageNet robustness (Fig. 12), or on segmentation after fine-tuning (Fig. 13), see
+Sec. 3.5.
+In Tab. 1 we provide predictions on DataComp-1.4B for both MaMMUT and CLIP for unseen
+compute budgets 2.14e+12 GFLOPs (corresponds to CLIP ViT-L-14 trained on 12.8B image-text
+pairs) and 2.59e+12 GFLOPs (corresponds to MaMMUT ViT-L-14 trained on 12.8B samples). We
+see that our predictions favor MaMMUT over CLIP. As a prediction test on larger scales further away,
+for CLIP ViT-L-14 trained on 12.8B samples of DataComp-1.4B our prediction for ImageNet-1k
+0-shot accuracy ( 79.6%) is close to performance of CLIP ViT-L-14 trained on 12.8B samples reported
+in the original DataComp work [ 19] -79.2%. The measured performance is well within the prediction
+confidence interval (Tab. 1). Note that the measured performance IN1K zero-shot 79.2%in the
+DataComp original work [ 19] was done with heavy samples repetitions (12.8B on DataComp-1.4B is
+about 9x), while our prediction is done for unique or low repetition scenario, which also might explain
+tendency to a higher performance in the prediction. In Tab. 5a we provide estimated parameters for
+our fits for both downstream tasks and datasets.
+3.2 Scaling laws for dataset comparison
+Derived scaling laws can be also be used as a tool for dataset comparison. Here, we compare
+performance of models trained on open reference datasets Re-LAION-1.4B, DataComp-1.4B and
+DFN-1.4B, for both model architectures – CLIP and MaMMUT, and for two downstream tasks –
+0-shot ImageNet-1k classification and MS-COCO retrieval.
+As we see from Fig. 4, for both CLIP and MaMMUT, training on DataComp-1.4B provides
+superior scalability for zero-shot ImageNet-1k classification , compared to training on Re-LAION-
+1.4B. At the same time, training either on Re-LAION-1.4B or DataComp-1.4B leads to similar
+Model Candidate Samples Seen Candidate GFLOPs IN1k acc1 Predicted (95% CI)
+ViT-L-14 12.8B 2.14e+12 0.796 (0.788, 0.804)
+ViT-L-14 15.5B 2.59e+12 0.800 (0.791, 0.808)
+mammut-ViT-L-14 10.6B 2.14e+12 0.816 (0.811, 0.821)
+mammut-ViT-L-14 12.8B 2.59e+12 0.820 (0.815, 0.826)
+Table 1: Estimation of IN1k performance for CLIP and MaMMUT on unseen compute scales using
+our scaling laws fits on DataComp-1.4B. Additionally, for each compute scale, we provide possible
+models and samples seen (assuming uniqie samples) sizes.
+5
+107108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 57.86*(x+exp(18.39))0.227+0.11
+MAMMUT: 125.36*(x+exp(19.29))0.256+0.10
+(a) ImageNet-1k 0-shot classification
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 56.57*(x+exp(18.43))0.233+0.22
+MAMMUT: 122.94*(x+exp(19.13))0.264+0.21
+ (b) MS-COCO image R@5
+Figure 1: Scaling on DataComp-1.4B. Comparison of CLIP and MaMMUT via scaling laws on
+DataComp-1.4B. Error rate on downstream tasks is plotted against compute. MaMMUT outperforms
+CLIP in terms of scalability, indicated by crossing scaling law fit lines, where MaMMUT takes over
+CLIP in performance from larger compute scale >1011GFLOPS on.
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 21.54*(x+exp(18.21))0.173+0.09
+MAMMUT: 25.41*(x+exp(19.18))0.169+0.00
+(a) ImageNet-1k 0-shot classification
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 41.22*(x+exp(18.03))0.219+0.21
+MAMMUT: 126.81*(x+exp(19.15))0.264+0.20
+ (b) MS-COCO image R@5
+Figure 2: Scaling on Re-LAION-1.4B. Comparison of CLIP and MaMMUT via scaling laws on
+Re-LAION-1.4B. Error rate on downstream tasks is plotted against compute. MaMMUT outperforms
+CLIP in terms of scalability, indicated by crossing scaling law fit lines, where MaMMUT takes over
+CLIP in performance from larger compute scale >1011GFLOPS on, showing similar trends as on
+DataComp-1.4B.
+scalability and performance on MS-COCO retrieval, with Re-LAION-1.4B being for retrieval slightly
+more beneficial (Fig. 5). For CLIP, we additionally plot OpenAI CLIP models’ performance that
+were trained on the WIT-400M dataset.
+Using much denser measurements for scaling law derivation, we can also confirm findings from
+previous work [ 10], which showed that the closed dataset WIT-400M[ 7] has better scaling trend on
+zero-shot classification, but worse scaling trend on zero-shot retrieval when compared to LAION-2B.
+We observe the same for Re-LAION-1.4B, which is a safety update of LAION-2B used in [ 10],
+otherwise being same dataset with less samples due to link rot [ 21]. This provides further evidence
+for robustness of scaling law based comparison, showing consistent trends despite major difference
+in scaling law derivation. Previous work [ 10] used few samples seen scales of 3B, 12.8B and 34B,
+which results in high repetition given that only 2B unique samples are contained in LAION-2B [ 42],
+while our work used denser lower samples seen scales up to 3B, doing derivation with unique samples
+or low repetition only. Despite these differences, derived scaling laws agree in the dataset comparison
+for each downstream task, predicting same scaling trends in favor of WIT-400M on classification
+and in favor of Re-LAION-1.4B on retrieval. DataComp-1.4B can be seen in this comparison as
+an improved version of Re-LAION-1.4B, with stronger scalability on classification (Fig. 4) that
+matches WIT-400M, while obtaining performance for retrieval (Fig. 5) that matches Re-LAION-1.4B,
+outperforming WIT-400M.
+6
+10710810910101011
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 9473.08*(x+exp(19.07))0.498+0.28
+MAMMUT: 3496.51*(x+exp(19.65))0.428+0.22
+(a) ImageNet-1k 0-shot classification
+10710810910101011
+Compute C [GFLOPs]100
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 1087.58*(x+exp(18.70))0.396+0.33
+MAMMUT: 519.92*(x+exp(19.25))0.34+0.26
+ (b) MS-COCO image R@5
+Figure 3: Scaling on DFN-1.4B. Comparison of CLIP and MaMMUT via scaling laws on DFN-1.4B.
+Error rate on downstream tasks is plotted against compute. MaMMUT outperforms CLIP in terms
+of scalability, indicated by crossing scaling law fit lines, where MaMMUT takes over CLIP in
+performance from larger compute close to 1011GFLOPS on, again showing similar trend as observed
+on DataComp and Re-LAION.
+107108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 57.86*(x+exp(18.39))0.227+0.11
+datacomp_1b
+CLIP: 21.54*(x+exp(18.21))0.173+0.09
+relaion2b-en
+CLIP: 24.49*(x+exp(16.95))0.162+0.00
+CLIP-WIT
+(a) IN-1k 0-shot error rate for openCLIP
+108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+MAMMUT: 25.41*(x+exp(19.18))0.169+0.00
+relaion2b-en
+MAMMUT: 125.36*(x+exp(19.29))0.256+0.10
+datacomp_1b (b) IN-1k 0-shot error rate for openMaMMUT
+Figure 4: Scaling laws for IN1k 0-shot performance of openCLIP (left) and openMaMMUT (right),
+comparing training on DataComp-1.4B and Re-LAION-1.4B. For CLIP we have 3 additional points
+for OpenAI CLIP [7] models trained on WIT-400M dataset for reference.
+We also provide comparison for Re-LAION, DataComp and DFN. For DFN, we measure only up to
+300M samples seen and up to L/14 model scale, therefore we base the comparison on measurements
+done up to compute scale of 1011GFLOPS. As evident from Fig. 6 and 7, training on DFN-
+1.4B provides stronger scalability and outperforms DataComp and Re-LAION for both zero-
+shot ImageNet-1k classification and MSCOCO retrieval , again consistently for both CLIP and
+MaMMUT architectures. Despite lower compute used for dataset comparison and higher uncertainty
+for the trends resulting from fewer measurements for DFN, measured trends are clear and consistent,
+allowing thus to draw conclusions favoring DFN-1.4B over other datasets in the comparison.
+3.3 Data efficiency and compute-optimal dataset size
+Fig. 8 illustrates that MaMMUT exhibits superior data efficiency relative to CLIP. In Fig. 8 (a) we
+see that MaMMUT achieves better performance on ImageNet-1k zero-shot image classification as
+the number of training samples increases. In Fig. 8 (b) MaMMUT requires fewer training samples to
+achieve compute optimal performance on ImageNet-1k zero-shot classification. This indicates that
+MaMMUT makes more effective use of training data than CLIP. Therefore, these trends suggest
+that MaMMUT generalizes better and scales more favorably with additional data. We also provide
+estimations for optimal number of training samples for unseen compute scales (see Tab. 2) for
+CLIP and MaMMUT trained on DataComp-1.4B. We use the predicted compute-optimal number of
+samples to estimate IN1k classification error rate using obtained power fit following eq. 2 (see Fig.
+7
+1071081091010101110121013
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 41.22*(x+exp(18.03))0.219+0.21
+relaion2b-en
+CLIP: 56.57*(x+exp(18.43))0.233+0.22
+datacomp_1b
+CLIP: 42.77*(x+exp(6.71))0.225+0.32
+CLIP-WIT(a) Error Rate for CLIP
+1071081091010101110121013
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+MAMMUT: 126.81*(x+exp(19.15))0.264+0.20
+relaion2b-en
+MAMMUT: 122.94*(x+exp(19.13))0.264+0.21
+datacomp_1b (b) Error Rate for MaMMUT
+Figure 5: Scaling laws for MS-COCO image retrieval performance (1- Recall@5) of openCLIP (left)
+and openMaMMUT (right), comparing training on DataComp-1.4B and Re-LAION-1.4B. For CLIP
+models we have 3 additional points for OpenAI CLIP [ 7] trained on WIT-400M dataset for reference.
+10710810910101011
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 2858.21*(x+exp(18.99))0.439+0.32
+datacomp_1b
+CLIP: 411.60*(x+exp(18.85))0.342+0.35
+relaion2b-en
+CLIP: 9473.08*(x+exp(19.07))0.498+0.28
+dfn_2b
+(a) IN-1k 0-shot error rate for openCLIP
+10710810910101011
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+MAMMUT: 60.22*(x+exp(19.30))0.22+0.15
+relaion2b-en
+MAMMUT: 518.67*(x+exp(19.54))0.331+0.19
+datacomp_1b
+MAMMUT: 3496.51*(x+exp(19.65))0.428+0.22
+dfn_2b (b) IN-1k 0-shot error rate for openMaMMUT
+Figure 6: Scaling laws for IN1k 0-shot performance of openCLIP (left) and openMaMMUT (right),
+comparing training on Re-LAION-1.4B, DataComp-1.4B and DFN-1.4B. Training on DFN-1.4B
+results in superior performance across scales consistently for both architectures.
+10710810910101011
+Compute C [GFLOPs]100
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 108.30*(x+exp(18.40))0.271+0.26
+relaion2b-en
+CLIP: 95.33*(x+exp(18.58))0.261+0.25
+datacomp_1b
+CLIP: 517.99*(x+exp(18.62))0.355+0.30
+dfn_2b
+(a) Error Rate for CLIP
+10810910101011
+Compute C [GFLOPs]100
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+MAMMUT: 473.30*(x+exp(19.36))0.335+0.27
+relaion2b-en
+MAMMUT: 273.04*(x+exp(19.29))0.307+0.26
+datacomp_1b
+MAMMUT: 305.73*(x+exp(19.15))0.312+0.23
+dfn_2b (b) Error Rate for MaMMUT
+Figure 7: Scaling laws for MS-COCO image retrieval performance (1- Recall@5) of openCLIP (left)
+and openMaMMUT (right), comparing training on Re-LAION-1.4B, DataComp-1.4B and DFN-1.4B.
+Training on DFN-1.4B results again in superior performance across scales consistently for both
+architectures.
+8). We see that MaMMUT is a more scalable model which agrees with estimation obtained from
+fitting eq. 1 on the experimental data (see Fig. 1 and App. Tab. 8).
+8
+1061071081091010
+Number of Samples100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 54186.54*(x+exp(17.23))0.645+0.19
+MAMMUT: 195979.42*(x+exp(17.14))0.722+0.19
+(a) IN-1k 0-Shot classification error rate vs. train-
+ing dataset size
+107108109101010111012
+Compute C [GFLOPs]1061071081091010Optimal Number of Samples Dopt(C)
+CLIP: 16.88*x0.74
+MAMMUT: 8.66*x0.74(b) Compute optimal dataset size Dopt(C)
+Figure 8: Comparison of data efficiency and optimal dataset size for CLIP and MaMMUT via scaling
+laws on DataComp-1.4B. MaMMUT is more data efficient and requires smaller dataset size to be
+compute optimal.
+GFLOPsPredicted
+Dopt(C)(95% CI)Model
+Candidate #ParamsPredicted IN1k
+0-shot acc (95% CI)
+2.14e+12 2.30e+10 (2.75e+10, 1.91e+10) ViT-SO150M-14-smaller-text 279M 0.794 (0.785, 0.803)
+2.59e+12 2.64e+10 (3.19e+10, 2.20e+10) ViT-SO150M-14-smaller-text 295M 0.795 (0.786, 0.804)
+2.14e+12 1.23e+10 (1.39e+10, 1.09e+10) mammut-ViT-L-14 522M 0.798 (0.794, 0.803)
+2.59e+12 1.42e+10 (1.61e+10, 1.25e+10) mammut-ViT-L-14 548M 0.799 (0.795, 0.804)
+Table 2: Predicted compute optimal samples seen and accuracy for each compute budget and model
+configuration, with parameter sizes annotated in millions (M).
+3.4 Scaling behavior of and comparison to other architectures
+We investigate additional model architectures: SigLIP [ 18] (CLIP with the sigmoid loss instead of
+softmax), CoCa [ 16] (contrastive + captioning loss using encoder-decoder text tower, as opposed to
+decoder only for MaMMUT) and Cap [ 43] (pure captioner). We train these models on DataComp-
+1.4B in order to compare with openCLIP and openMaMMUT. Fig. 9 shows the fitted lines for
+these models. We see that CLIP and SigLIP have very similar scaling behavior on ImageNet-1k
+classification (Fig. 9 (a)) while openMaMMUT consistently overtakes CoCa on the same compute
+scale Fig. 9 (b). Notably, our analysis shows that SigLIP has similar or even worse scalability than
+CLIP which contradicts recent claims of SigLIP being a better choice for a vision encoder [ 18,14]
+due to its architectural advantages (specifically, due to usage of sigmoid transfer function instead of
+softmax). Thus, when properly controlling for same training data in our experiments, no benefits for
+SigLIP can be derived from the obtained scaling law trends. We also observe that text decoder-only
+MaMMUT overtakes encoder-decoder CoCa on the same compute scale , indicating that simpler
+and more parameter efficient architecture of MaMMUT might be preferable.
+Moreover, we see (Fig. 10) that MaMMUT has superior scaling compared to Cap, showing that
+combination of contrastive and captioning losses is advantageous . We see Cap also underperform-
+ing standard CLIP, hinting that Cap as captioner only based architecture is not a good candidate for
+strong scalability in 0-shot regimes, making another case for contrastive losses being important part
+of scalable architectures for 0-shot classification. It is further important to note that Cap can use only
+log-likelihood based evaluation for zero-shot classification task, as opposed to CLIP and MaMMUT
+that in addition can use embedding similarity based evaluation thanks to their contrastive loss. As
+evident from Fig. 10, embedding similarity based evaluation used in openCLIP and openMaMMUT
+has strong advantage over log-likelihood based one. It is in addition also much cheaper in execution.
+Cap has thus architectural disadvantage in not being able to use similarity based evaluation due to
+missing contrastive loss, which leads to inferior performance in 0-shot regime.
+For both comparisons, we see uncertainty getting high when extrapolating to larger scales, which
+makes it for instance hard to predict whether CoCa might still cross CLIP or not. To reduce
+9
+1071081091010
+Compute C [GFLOPs]100
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 236.80*(x+exp(18.68))0.306+0.22
+SIGLIP: 160.93*(x+exp(18.65))0.285+0.21
+(a) CLIP vs SiGLIP on DataComp-1.4B
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 54.68*(x+exp(18.21))0.227+0.14
+COCA: 87.11*(x+exp(19.44))0.236+0.11
+MAMMUT: 218.02*(x+exp(19.41))0.285+0.14
+ (b) MaMMUT vs CoCa vs CLIP on DataComp-
+1.4B
+Figure 9: Scaling laws for ImageNet-1k 0-shot classification, comparing SigLIP ( left) and CoCa
+(right ) with standard CLIP and MaMMUT using open DataComp-1.4B dataset. SigLIP shows no
+benefit over standard CLIP, contrary to claims in previous work. CoCa is predicted to be outperformed
+by MaMMUT. CoCa crossing CLIP is possible, hinting stronger scalability for CoCa over CLIP. This
+prediction is not clear due to high uncertainty for CoCa estimates at larger scales, as measurements
+on smaller scales for CoCa are not dense enough.
+107108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CAP: 16.23*(x+exp(20.12))0.139+0.00
+CLIP: 57.86*(x+exp(18.39))0.227+0.11
+MAMMUT: 125.36*(x+exp(19.29))0.256+0.10
+Figure 10: Scaling law fit for ImageNet-1k 0-shot classification, comparing MaMMUT, CLIP and
+Cap (captioning only). Cap can be only evaluated via log-likelihood, which is more expensive
+as similarity based evaluation used by CLIP and MaMMUT, as Cap misses contrastive loss in its
+architecture, which makes it disadvantageous for 0-shot setting.
+uncertainty, it is thus important to both conduct dense measurements at smaller scales and not to cut
+off measurements at scales too small to be used for proper extrapolation.
+3.5 Scaling laws and comparison on additional downstream tasks
+We also fit scaling laws on the data for other downstream tasks. In the Fig. 11 we show the scaling
+behavior on DataComp eval suite, which is constituted by averaging over 35 classification tasks from
+DataComp (see Tab.15 from [ 19]). Additionally, we provide scaling law fits for ImageNet-V2 and full
+ImageNet robustness set 0-shot classification performance for both openMaMMUT and openCLIP
+(Fig. 12). For all of these tasks we see the same trend - openMaMMUT is stronger scalable than
+openCLIP and has higher performance given the same compute at larger compute scales. This is also
+valid for the important robustness metrics that reflects out-of-distribution generalization (Fig. 12)
+- openMaMMUT shows stronger scalable robustness and outperforms openCLIP in robustness at
+larger compute scales.
+Scaling law for fine-tuning error on segmentation dense prediction task For further comparison
+evidence, we derive a scaling law (Eq. 1) for ADE20K segmentation error ( 1−mIoU ) after fine-tuning
+10
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+DataComp Eval Suite 0-shot [Error Rate]
+CLIP: 18.19*(x+exp(17.27))0.179+0.14
+MAMMUT: 19.10*(x+exp(18.04))0.169+0.07
+Figure 11: Scaling law on DataComp evaluation suite (average over 35 tasks, 0-shot classification),
+openCLIP vs. openMaMMUT comparison on DataComp-1.4B
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+ImageNet1k-V2 [Error Rate]
+CLIP: 27.24*(x+exp(18.41))0.188+0.15
+MAMMUT: 19.72*(x+exp(18.99))0.158+0.02
+(a) ImageNet V2
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+ImageNet1k-Robustness [Error Rate]
+CLIP: 13.47*(x+exp(18.94))0.138+0.00
+MAMMUT: 31.69*(x+exp(20.14))0.172+0.00
+ (b) ImageNet Robustness
+Figure 12: Scaling laws for ImageNet-v2 (left) and ImageNet robustness set (right, averaged perfor-
+mance across 5 datasets ImageNet-v2[ 27], ImageNet-R[ 28], ImageNet-Sketch[ 30], ObjectNet[ 31],
+and ImageNet-A[ 29]), 0-shot classification for openCLIP and openMaMMUT comparison on
+DataComp-1.4B
+dependent on pre-training compute scale for CLIP and MaMMUT. As shown in Fig. 13, MaMMUT
+again exhibits stronger scaling than CLIP ( α=−0.208vs.−0.354), with an error crossover at
+approximately 109GFLOPs. This is far below the crossover at approximately 1011GFLOPs observed
+for zero-shot ImageNet classification (Fig. 1a), indicating that captioning supervision via fine-tuning
+improves dense prediction already at lower pre-training scales. See more details in Appendix E.
+3.6 Scaling law derivation using constant learning rate scheduler
+We follow [ 44] and show a scaling law derivation based on training with constant learning rate, thus
+saving 98% of compute compared to cosine. We omit points from warmup duration in our derivation,
+to prevent noise in the low-compute part of the scaling law. In Fig. 14 we visualize our results,
+showing the measurements density and in App. Tab. 6 we tabulate the coefficients. Our results further
+support the better scalability of MaMMUT over CLIP, showing consistent trends even when replacing
+learning rate scheduler. Note that crossing point of MaMMUT overtaking CLIP is again consistently
+estimated to be between 1010and1011GFLOPS when using const lr schedule, as also observed for
+cosine schedule and across various datasets.
+3.7 Scaling up following the comparison: OpenMaMMUT-L-14
+OpenMaMMUT-L-14 is a large scale open vision-language foundation model. Training hyperpa-
+rameters can be found in Tab. 4. We used insights from our scaling analysis to guide our choice
+of model and dataset scale. OpenMaMMUT achieves state of the art performance on zero-shot
+11
+107108109101010111012
+Compute C [GFLOPs]5×101
+6×101
+7×101
+8×101
+9×101
+ADE20K Semantic Segmentation [Error Rate]
+CLIP: 17.93*(x+exp(17.49))0.208+0.47
+MAMMUT: 331.17*(x+exp(18.73))0.354+0.50
+Figure 13: Scaling law for semantic segmentation. Downstream error rate (1 – mIoU) of openCLIP
+and openMaMMUT pre-trained on DataComp-1.4B and fine-tuned on ADE20K. MaMMUT shows
+higher performance than CLIP for segmentation at higher scales. Crossing point appears earlier
+around 109GFLOPS, which might be due to fine-tuning used for this task, as opposed to zero-shot
+evaluation applied everywhere else.
+10610710810910101011
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 14.77*(x+exp(16.72))0.168+0.12
+MAMMUT: 1850.29*(x+exp(20.52))0.379+0.20
+(a) ImageNet-1k 0-shot classification
+10610710810910101011
+Compute C [GFLOPs]100
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 6.69*(x+exp(16.21))0.123+0.09
+MAMMUT: 634.19*(x+exp(20.26))0.335+0.25
+ (b) MS-COCO image R@5
+Figure 14: Scaling law fits using constant learning rate scheduler. Comparison of CLIP and
+MaMMUT via scaling laws on DataComp-1.4B. Error rate on downstream tasks is plotted against
+compute. Using constant learning rate scheduler for scaling law derivation reveals the same trend
+as with cosine - MaMMUT outperforms CLIP in terms of scalability, with crossing point again
+consistently found to be between 1010and1011GFLOPS as observed for cosine schedule and across
+various datasets.
+classification and retrieval tasks among similar-sized models trained only on publicly-available data
+(MetaCLIP, DataComp, OpenVision, Tab. 3). It outperforms with 80.3% IN1k accuracy as predicted
+openCLIP pre-trained on same DataComp-1.4B budget of 12.8B ( 79.2%) and even rivals models with
+much larger pre-training compute like SigLIP. OpenMaMMUT represents a highly performant, fully
+reproducible alternative to other models with openly available data and training code . Note that on
+12.8B samples seen scale the performance suffers from high amount of repetitions, and therefore is
+below our prediction of 82% (Tab. 1) that is valid for training on unique samples.
+4 Related work & limitations
+Recent work has investigated the performance of vision-language models such as CLIP [ 7], CoCa
+[16], MaMMUT [ 17], Cap [ 43], SigLIP [ 14], TULIP[ 47] or OpenVision[ 48] at various scales.
+These studies analyze different model sizes and highlight either architectural or dataset innovations;
+however, they do not perform a comprehensive scaling law analysis. Furthermore, the datasets used
+in these works—such as WIT for OpenAI CLIP and WebLI for SigLIP—are closed , severely limiting
+reproducibility and making it impossible to study which of algorithmic or dataset interventions
+12
+ImageNet-1k COCO
+ViT Res. Seq. Model Dataset #Samples val v2 T →I I →T
+L/16 256 256SigLIP [18] WebLI-10B 40B 80.44 73.76 75.26 88.40
+SigLIP 2 [14] WebLI-10B 40B 82.35 76.66 76.84 90.44
+L/14 224 256OpenCLIP [10] LAION-2B 34B 75.24 67.73 70.46 84.30
+CLIP [7] WIT-400M 12.8B 75.54 69.84 59.95 79.56
+MetaCLIP [45] MetaCLIP-2.5B 12.8B 79.19 72.64 71.36 84.94
+EV A-CLIP [46] Merged-2B 4B∗79.75∗72.92∗70.68 85.26
+DFN [20] DFN-2B 13B 81.41∗74.58∗73.19∗86.20∗
+DataComp [19] DataComp-1.4B 12.8B 79.19 72.06 69.86 84.64
+OpenMaMMUT (Ours) DataComp-1.4B 12.8B 80.34 73.78 71.19 85.88
+Table 3: Zero-shot classification (accuracy) and retrieval (R@5) results. DFN used ImageNet/MS-
+COCO-finetuned model for data filtering; EV A-CLIP was initialized from models pre-trained on
+ImageNet. We use bold for best overall results, gray for models involving ImageNet/MS-COCO data
+as training data in pipeline, and underlined for best results without ImageNet/MS-COCO involvement.
+Hyperparameter Value
+Model Architecture mammut-ViT-L-14
+Samples Seen 12.8B
+Warmup Steps 6000
+Global Batch Size 180,224
+Learning Rate 2.5×10−3
+GPU Hours 3.53×104
+Number of NVIDIA A100 GPUs 1024
+Table 4: Training hyperparameters for openMaMMUT-L-14.
+claimed to have beneficial effect on learning used in those studies indeed lead to better model
+performance. Using our procedure, we can check such claims. For instance in Fig. 9, we compare
+open implementations of CoCa and SigLIP to openCLIP and openMaMMUT on DataComp-1.4B,
+finding no significant difference of SigLIP to standard CLIP in model scalability. We also observe
+advantage for MaMMUT over CoCa on same compute budget, while both architectures use the same
+contrastive and captioning loss combination.
+In [49], authors investigate how various language model families compare in terms of their scaling
+behavior. While it offers valuable insights into architectural trends, it does not use for comparison a
+full scaling law framework in the sense of jointly modeling loss or downstream task performance as a
+function of compute and dataset size varied systematically across multiple scales. As accuracy of
+predictions derived from such trends was not measured, it makes it unclear whether observed trends
+for various language model architectures are to be trusted and whether comparison would remain
+valid across various scenarios, which we demonstrate to be the case for scaling law based comparison.
+Preparing grounds for this work, [ 10] derived first reproducible scaling laws for openCLIP using
+LAION datasets and performed comparison between open LAION-400M/5B and closed WIT. The
+work used however only few samples seen scales (3B, 12.8B and 34B), while also going up to scales
+that are prone to strongly diminishing performance due to heavy sample repetition (6x on 12.8B and
+17x on 34B sample seen scales). This affects extrapolations of the scaling law and thus the validity of
+comparisons based on it. Interestingly, in our work using much denser scaling law derivation without
+strong repetitions for higher prediction accuracy, we can confirm the dataset comparison in [ 10] using
+Re-LAION-1.4B, observing same trends for WIT being better on zero-shot classification (Fig. 4)
+while worse on retrieval (Fig. 5), providing further evidence for robustness of scaling law based
+comparison. Another data-centric work responsible for composing open DataComp-1.4B dataset
+[19] used measurements on few selected scales to compare datasets and decide for benefit of various
+dataset interventions. No scaling laws were derived to back up the comparisons, leaving unclear
+whether the observed trends will propagate across larger scales than taken for the comparisons.
+Several works explored the effects of data constraints on scaling laws. Notably, studies investigating
+the scaling law behavior under dataset repetitions for language models [ 38,41] and for CLIP[ 50]
+reported that high repetition factors can lead to heavily diminished performance compared to the
+Pareto front of scaling with unique data samples. Our experiments carefully limit the repetition factor
+13
+to less than 3 ×, minimizing such confounding effects, assuming unique samples or only little sample
+repetition for comparisons to be valid on Pareto front with strong performance scaling.
+Building on these foundations, our work provides a unified and empirically grounded scaling law
+analysis of vision-language models trained on open datasets. We explicitly model performance as
+a function of data and compute [ 8,9], and compare multiple architectures under fully controlled,
+consistent and reproducible settings. Unlike prior work, our approach enables rigorous comparison
+of both data and compute efficiency, ensuring the consistency of the comparison across scales and
+training conditions.
+Limitations. While our work provides a comprehensive analysis for language-vision models such as
+CLIP and MaMMUT trained on large-scale open foundation datasets, it also has several limitations:
+1)We mostly use zero-shot setting for model evaluation (for classification and retrieval tasks), using
+fine-tuning only for segmentation. Linear probing, fine-tuning [ 10] or vision instruction-tuning [ 12]
+of the pre-trained vision encoders can provide further insights into validity and consistency of scaling
+laws based comparison. 2)While open datasets we use have substantial scale - 1.4B unique samples -
+this still limits the ability of derived scaling laws to extrapolate to higher scales, as the effect of sample
+repetition has to be considered when conducting measurements above 1.4B. To test comparison
+validity and scaling law predictions on larger reference scales like 12.8B, larger scale open datasets
+are required. 3)In our study we only looked at standard contrastive loss or contrastive and captioning
+loss objectives and did not incorporate further "loss mixtures" such as masking or diffusion-based
+losses. We also did not derive scaling laws for specific architectural components such as optimal
+number of parameters in text or vision tower, or other important properties of training procedure like
+image input resolution and patch size, or context length in general. In its current form, scaling laws
+based comparison has high computational cost, prohibiting naive incorporation of many factors that
+influence scalability of the training procedure.
+5 Discussion & conclusion
+In this work, we show how open foundation models trained on open datasets can provide grounds
+for systematic learning procedure comparison via scaling law derivation under fully controlled,
+reproducible training conditions. We take as example scenario openCLIP [ 7,22,10] and open-
+MaMMUT based on [ 17] , two important open language-vision models relying either on image-text
+contrastive only or contrastive and captioning loss, trained on three important open reference datasets,
+DataComp-1.4B [ 19], Re-LAION-1.4B [ 21] and DFN-1.4B [ 20]. We show that deriving scaling
+laws gives comparison of model and dataset based on their estimated scalability for wide scale spans
+and for various downstream tasks, aligned on same total pre-training compute. Such comparison
+can be validated by checking consistency of scaling trends in different scenarios. For instance,
+openMaMMUT scalability is stronger than openCLIP both on zero-shot classification and retrieval,
+also showing advantage for a wide scale span on segmentation, and across all three studied datasets
+DataComp-1.4B, Re-LAION-1.4B and DFN-1.4B. Also, inconsistencies are insightful - for instance,
+DataComp-1.4B shows stronger scalability for both openMaMMUT and openCLIP for zero-shot
+classification while being slightly weaker for retrieval. Thus, none of these two datasets is the most
+scalable candidate across all downstream tasks, and scaling advantage there is task dependent. For
+DFN on the other hand, a consistent picture emerges: both openMaMMUT and openCLIP trained
+on DFN show superior performance over other datasets across downstream tasks, allowing to draw
+conclusion favoring DFN over other datasets for pretraining strong and scalable models.
+Comparison via scaling laws offers better protection against misleading conclusions derived from
+comparison of only few selected points, especially when done on small scales only. On smaller
+scales, openCLIP outperforms stronger scalable openMaMMUT that takes over on larger scales.
+Remarkably, we observe the compute scale threshold where openMaMMUT takes over openCLIP
+to be consistently settled between 1010and1011GFLOPS across datasets, zero-shot downstream
+tasks and learning schedules. This gives further evidence for the robustness of scaling law based
+comparison. To properly estimate such crossings, it is crucial to perform dense measurements on
+smaller scales and use fitting routines that allow for accurate extrapolation to larger scales. Efficient
+derivation of accurate scaling laws [ 44,11] for factors affecting the learning procedure is thus an
+important topic for future work.
+14
+In our study, we used open datasets with 1.4B samples. While this is sufficient to demonstrate
+usefulness of scaling law based comparison, more accurate predictions for training at larger scales
+on unique samples require larger datasets. Those are also required to train larger scale models with
+predicted strong capabilities, as too many repetitions on smaller datasets might lead to diminished
+performance [ 41,50], which we see in openMaMMUT L-14 trained on 12.8B samples, staying
+with zero-shot IN1k 80.3% below the predicted 82% (Tab. 1). Deriving scaling law correction for
+diminishing performance due to data repetitions as well as increasing scale of open datasets are
+important directions for future work.
+While we show that robust and reproducible comparison via scaling law derivation is possible, it
+relies crucially on the whole pipeline to be fully open - including dataset composition, training
+itself, and downstream evaluation. We hope that our work will encourage the creation of more open
+artefacts, especially open datasets as those are still scarce [ 42,19,20,21], to enable collaborative and
+reproducible progress towards stronger scalable open foundation models guided by independently
+verifiable and systematic comparison.
+Acknowledgements
+MN, TP, MC and JJ acknowledge funding by the Federal Ministry of Education and Research
+of Germany (BMBF) under grant no. 01IS24085C (OPENHAFM), under the grant 16HPC117K
+(MINERV A) and under the grant no. 01IS22094B (WestAI - AI Service Center West), as well as co-
+funding by EU from EuroHPC Joint Undertaking programm under grant no. 101182737 (MINERV A)
+and from Digital Europe Programme under grant no. 101195233 (openEuroLLM).
+We gratefully acknowledge the Gauss Centre for Supercomputing e.V . for funding this work by
+providing computing time through the John von Neumann Institute for Computing (NIC) on the su-
+percomputer JUWELS Booster at Jülich Supercomputing Centre (JSC), EuroHPC Joint Undertaking
+for computing time and storage on the EuroHPC supercomputer LEONARDO, hosted by CINECA
+(Italy) and the LEONARDO consortium through an EuroHPC Extreme Access grant EHPC-EXT-
+2023E02-068, storage resources on JUST granted and operated by JSC and supported by Helmholtz
+Data Federation (HDF), computing time granted by the JARA and JSC on the supercomputer JU-
+RECA at JSC, and computing time granted on prototype JEDI via JUREAP (JUPITER Early Access
+Programm) grant at JSC.
+Further thanks go for support provided by supercomputing facilities and their teams, especially to
+Damian Alvarez and Mathis Bode from Juelich Supercomputer Center (JSC, Germany) and to Laura
+Morselli from CINECA (Italy).
+We also would like to express gratitude to all the people who are working on making code, models and
+data publicly available, advancing community based research and making research more reproducible.
+Specifically, we would like to thank all the members of the LAION Discord server2community and
+Open- Ψ(Open-Sci) Collective3for providing fruitful ground for scientific exchange and open-source
+development.
+References
+[1]Rishi Bommasani, Drew A Hudson, Ehsan Adeli, Russ Altman, Simran Arora, Sydney von
+Arx, Michael S Bernstein, Jeannette Bohg, Antoine Bosselut, Emma Brunskill, et al. On the
+opportunities and risks of foundation models. arXiv preprint arXiv:2108.07258 , 2021.
+[2]Jacob Devlin, Ming-Wei Chang, Kenton Lee, and Kristina Toutanova. Bert: Pre-training of
+deep bidirectional transformers for language understanding. arXiv preprint arXiv:1810.04805 ,
+2018.
+[3]Colin Raffel, Noam Shazeer, Adam Roberts, Katherine Lee, Sharan Narang, Michael Matena,
+Yanqi Zhou, Wei Li, and Peter J Liu. Exploring the limits of transfer learning with a unified
+text-to-text transformer. Journal of machine learning research , 21(140):1–67, 2020.
+2https://discord.gg/BZqhreFazY
+3https://discord.gg/GsKh4mBVcv
+15
+[4]Tom Brown, Benjamin Mann, Nick Ryder, Melanie Subbiah, Jared D Kaplan, Prafulla Dhariwal,
+Arvind Neelakantan, Pranav Shyam, Girish Sastry, Amanda Askell, et al. Language models are
+few-shot learners. Advances in neural information processing systems , 33:1877–1901, 2020.
+[5]David Fan, Shengbang Tong, Jiachen Zhu, Koustuv Sinha, Zhuang Liu, Xinlei Chen, Michael
+Rabbat, Nicolas Ballas, Yann LeCun, Amir Bar, et al. Scaling language-free visual representa-
+tion learning. arXiv preprint arXiv:2504.01017 , 2025.
+[6]Benjamin Elizalde, Soham Deshmukh, Mahmoud Al Ismail, and Huaming Wang. Clap learning
+audio concepts from natural language supervision. In ICASSP 2023-2023 IEEE International
+Conference on Acoustics, Speech and Signal Processing (ICASSP) , pages 1–5. IEEE, 2023.
+[7]Alec Radford, Jong Wook Kim, Chris Hallacy, Aditya Ramesh, Gabriel Goh, Sandhini Agarwal,
+Girish Sastry, Amanda Askell, Pamela Mishkin, Jack Clark, et al. Learning transferable visual
+models from natural language supervision. In International Conference on Machine Learning ,
+pages 8748–8763. PMLR, 2021.
+[8]Jared Kaplan, Sam McCandlish, Tom Henighan, Tom B Brown, Benjamin Chess, Rewon Child,
+Scott Gray, Alec Radford, Jeffrey Wu, and Dario Amodei. Scaling laws for neural language
+models. arXiv preprint arXiv:2001.08361 , 2020.
+[9]Jordan Hoffmann, Sebastian Borgeaud, Arthur Mensch, Elena Buchatskaya, Trevor Cai, Eliza
+Rutherford, Diego de las Casas, Lisa Anne Hendricks, Johannes Welbl, Aidan Clark, Tom
+Hennigan, Eric Noland, Katherine Millican, George van den Driessche, Bogdan Damoc, Aurelia
+Guy, Simon Osindero, Karen Simonyan, Erich Elsen, Oriol Vinyals, Jack William Rae, and
+Laurent Sifre. An empirical analysis of compute-optimal large language model training. In
+Alice H. Oh, Alekh Agarwal, Danielle Belgrave, and Kyunghyun Cho, editors, Advances in
+Neural Information Processing Systems , 2022.
+[10] Mehdi Cherti, Romain Beaumont, Ross Wightman, Mitchell Wortsman, Gabriel Ilharco, Cade
+Gordon, Christoph Schuhmann, Ludwig Schmidt, and Jenia Jitsev. Reproducible scaling laws
+for contrastive language-image learning. In Proceedings of the IEEE/CVF conference on
+computer vision and pattern recognition , pages 2818–2829, 2023.
+[11] Margaret Li, Sneha Kudugunta, and Luke Zettlemoyer. (mis)fitting scaling laws: A survey of
+scaling law fitting techniques in deep learning. In The Thirteenth International Conference on
+Learning Representations , 2025.
+[12] Haotian Liu, Chunyuan Li, Qingyang Wu, and Yong Jae Lee. Visual instruction tuning. Advances
+in neural information processing systems , 36:34892–34916, 2023.
+[13] Zhe Chen, Jiannan Wu, Wenhai Wang, Weijie Su, Guo Chen, Sen Xing, Muyan Zhong, Qinglong
+Zhang, Xizhou Zhu, Lewei Lu, et al. Internvl: Scaling up vision foundation models and aligning
+for generic visual-linguistic tasks. In Proceedings of the IEEE/CVF conference on computer
+vision and pattern recognition , pages 24185–24198, 2024.
+[14] Michael Tschannen, Alexey Gritsenko, Xiao Wang, Muhammad Ferjad Naeem, Ibrahim Alab-
+dulmohsin, Nikhil Parthasarathy, Talfan Evans, Lucas Beyer, Ye Xia, Basil Mustafa, et al. Siglip
+2: Multilingual vision-language encoders with improved semantic understanding, localization,
+and dense features. arXiv preprint arXiv:2502.14786 , 2025.
+[15] Dustin Podell, Zion English, Kyle Lacey, Andreas Blattmann, Tim Dockhorn, Jonas Müller, Joe
+Penna, and Robin Rombach. Sdxl: Improving latent diffusion models for high-resolution image
+synthesis. arXiv preprint arXiv:2307.01952 , 2023.
+[16] Jiahui Yu, Zirui Wang, Vijay Vasudevan, Legg Yeung, Mojtaba Seyedhosseini, and Yonghui
+Wu. Coca: Contrastive captioners are image-text foundation models. arXiv preprint
+arXiv:2205.01917 , 2022.
+[17] Weicheng Kuo, AJ Piergiovanni, Dahun Kim, xiyang luo, Benjamin Caine, Wei Li, Abhijit
+Ogale, Luowei Zhou, Andrew M. Dai, Zhifeng Chen, Claire Cui, and Anelia Angelova. MaM-
+MUT: A simple architecture for joint learning for multimodal tasks. Transactions on Machine
+Learning Research , 2023.
+16
+[18] Xiaohua Zhai, Basil Mustafa, Alexander Kolesnikov, and Lucas Beyer. Sigmoid loss for
+language image pre-training. In Proceedings of the IEEE/CVF international conference on
+computer vision , pages 11975–11986, 2023.
+[19] Samir Yitzhak Gadre, Gabriel Ilharco, Alex Fang, Jonathan Hayase, Georgios Smyrnis, Thao
+Nguyen, Ryan Marten, Mitchell Wortsman, Dhruba Ghosh, Jieyu Zhang, et al. Datacomp:
+In search of the next generation of multimodal datasets. Advances in Neural Information
+Processing Systems , 36:27092–27112, 2023.
+[20] Alex Fang, Albin Madappally Jose, Amit Jain, Ludwig Schmidt, Alexander Toshev, and
+Vaishaal Shankar. Data filtering networks. In The Twelfth International Conference on Learning
+Representations , 2024.
+[21] LAION. Releasing re-laion 5b: transparent iteration on laion-5b with additional safety fixes.
+https://laion.ai/blog/relaion-5b/ , 2024. Accessed: 30 aug, 2024.
+[22] G. Ilharco, M. Wortsman, N. Carlini, R. Taori, A. Dave, V . Shankar, H. Namkoong, J. Miller,
+H. Hajishirzi, A. Farhadi, and L. Schmidt. Openclip. 2021.
+[23] Aaron van den Oord, Yazhe Li, and Oriol Vinyals. Representation learning with contrastive
+predictive coding. arXiv preprint arXiv:1807.03748 , 2018.
+[24] Ilya Loshchilov and Frank Hutter. Decoupled weight decay regularization. arXiv preprint
+arXiv:1711.05101 , 2017.
+[25] Melanie Mitchell. How do we know how smart ai systems are? Science , 381(6654):eadj5957,
+2023.
+[26] J. Deng, W. Dong, R. Socher, L. Li, Kai Li, and Li Fei-Fei. Imagenet: A large-scale hierarchical
+image database. In Proc. IEEE Conf. Computer Vision and Pattern Recognition , pages 248–255,
+June 2009.
+[27] Benjamin Recht, Rebecca Roelofs, Ludwig Schmidt, and Vaishaal Shankar. Do imagenet
+classifiers generalize to imagenet? In International conference on machine learning , pages
+5389–5400. PMLR, 2019.
+[28] Dan Hendrycks, Steven Basart, Norman Mu, Saurav Kadavath, Frank Wang, Evan Dorundo,
+Rahul Desai, Tyler Zhu, Samyak Parajuli, Mike Guo, Dawn Song, Jacob Steinhardt, and Justin
+Gilmer. The many faces of robustness: A critical analysis of out-of-distribution generalization.
+International Conference on Computer Vision (ICCV) , 2021. https://arxiv.org/abs/
+2006.16241 .
+[29] Dan Hendrycks, Kevin Zhao, Steven Basart, Jacob Steinhardt, and Dawn Song. Natural
+adversarial examples. Conference on Computer Vision and Pattern Recognition (CVPR) , 2021.
+https://arxiv.org/abs/1907.07174 .
+[30] Haohan Wang, Songwei Ge, Zachary Lipton, and Eric P Xing. Learning robust global represen-
+tations by penalizing local predictive power. In Advances in Neural Information Processing
+Systems (NeurIPS) , 2019. https://arxiv.org/abs/1905.13549 .
+[31] Andrei Barbu, David Mayo, Julian Alverio, William Luo, Christopher Wang, Dan Gutfreund,
+Josh Tenenbaum, and Boris Katz. Objectnet: A large-scale bias-controlled dataset for pushing
+the limits of object recognition models. In Advances in Neural Information Processing Systems
+(NeurIPS) , 2019.
+[32] Romain Beaumont Mehdi Cherti et al. Clip benchmark. https://github.com/LAION-AI/
+CLIP_benchmark , 2023.
+[33] Tsung-Yi Lin, Michael Maire, Serge Belongie, James Hays, Pietro Perona, Deva Ramanan, Piotr
+Dollár, and C Lawrence Zitnick. Microsoft coco: Common objects in context. In European
+conference on computer vision , pages 740–755. Springer, 2014.
+[34] Bolei Zhou, Hang Zhao, Xavier Puig, Sanja Fidler, Adela Barriuso, and Antonio Torralba.
+Scene Parsing through ADE20K Dataset. In Proceedings of the IEEE/CVF Conference on
+Computer Vision and Pattern Recognition (CVPR) , pages 5122–5130, 2017.
+17
+[35] Tommie Kerssies, Daan De Geus, and Gijs Dubbelman. How to Benchmark Vision Foundation
+Models for Semantic Segmentation? In Proceedings of the IEEE/CVF Conference on Computer
+Vision and Pattern Recognition (CVPR) Workshops , pages 1162–1171, 2024.
+[36] Tommie Kerssies, Niccolò Cavagnero, Alexander Hermans, Narges Norouzi, Giuseppe Averta,
+Bastian Leibe, Gijs Dubbelman, and Daan de Geus. Your ViT is Secretly an Image Segmen-
+tation Model. In Proceedings of the IEEE/CVF Conference on Computer Vision and Pattern
+Recognition (CVPR) , 2025.
+[37] Xiaohua Zhai, Alexander Kolesnikov, Neil Houlsby, and Lucas Beyer. Scaling vision transform-
+ers. In Proceedings of the IEEE/CVF conference on computer vision and pattern recognition ,
+pages 12104–12113, 2022.
+[38] Tom Henighan, Jared Kaplan, Mor Katz, Mark Chen, Christopher Hesse, Jacob Jackson,
+Heewoo Jun, Tom B Brown, Prafulla Dhariwal, Scott Gray, et al. Scaling laws for autoregressive
+generative modeling. arXiv preprint arXiv:2010.14701 , 2020.
+[39] Jordan Hoffmann, Sebastian Borgeaud, Arthur Mensch, Elena Buchatskaya, Trevor Cai, Eliza
+Rutherford, Diego de Las Casas, Lisa Anne Hendricks, Johannes Welbl, Aidan Clark, et al.
+Training compute-optimal large language models. arXiv preprint arXiv:2203.15556 , 2022.
+[40] Stephan Borzsony, Donald Kossmann, and Konrad Stocker. The skyline operator. In Proceedings
+17th international conference on data engineering , pages 421–430. IEEE, 2001.
+[41] Niklas Muennighoff, Alexander Rush, Boaz Barak, Teven Le Scao, Nouamane Tazi, Aleksandra
+Piktus, Sampo Pyysalo, Thomas Wolf, and Colin A Raffel. Scaling data-constrained language
+models. Advances in Neural Information Processing Systems , 36:50358–50376, 2023.
+[42] Christoph Schuhmann, Romain Beaumont, Richard Vencu, Cade W Gordon, Ross Wightman,
+Mehdi Cherti, Theo Coombes, Aarush Katta, Clayton Mullis, Mitchell Wortsman, Patrick
+Schramowski, Srivatsa R Kundurthy, Katherine Crowson, Ludwig Schmidt, Robert Kaczmar-
+czyk, and Jenia Jitsev. LAION-5B: An open large-scale dataset for training next generation
+image-text models. In Thirty-sixth Conference on Neural Information Processing Systems
+(NeurIPS), Datasets and Benchmarks Track , 2022.
+[43] Michael Tschannen, Manoj Kumar, Andreas Steiner, Xiaohua Zhai, Neil Houlsby, and Lucas
+Beyer. Image captioners are scalable vision learners too. Advances in Neural Information
+Processing Systems , 36:46830–46855, 2023.
+[44] Tomer Porian, Mitchell Wortsman, Jenia Jitsev, Ludwig Schmidt, and Yair Carmon. Resolving
+discrepancies in compute-optimal scaling of language models. Advances in Neural Information
+Processing Systems , 37:100535–100570, 2024.
+[45] Hu Xu, Saining Xie, Xiaoqing Ellen Tan, Po-Yao Huang, Russell Howes, Vasu Sharma, Shang-
+Wen Li, Gargi Ghosh, Luke Zettlemoyer, and Christoph Feichtenhofer. Demystifying clip data.
+arXiv preprint arXiv:2309.16671 , 2023.
+[46] Quan Sun, Yuxin Fang, Ledell Wu, Xinlong Wang, and Yue Cao. Eva-clip: Improved training
+techniques for clip at scale. arXiv preprint arXiv:2303.15389 , 2023.
+[47] Zineng Tang, Long Lian, Seun Eisape, XuDong Wang, Roei Herzig, Adam Yala, Alane Suhr,
+Trevor Darrell, and David M Chan. Tulip: Towards unified language-image pretraining. arXiv
+preprint arXiv:2503.15485 , 2025.
+[48] Xianhang Li, Yanqing Liu, Haoqin Tu, Hongru Zhu, and Cihang Xie. Openvision: A fully-open,
+cost-effective family of advanced vision encoders for multimodal learning. arXiv preprint
+arXiv:2505.04601 , 2025.
+[49] Yi Tay, Mostafa Dehghani, Samira Abnar, Hyung Won Chung, William Fedus, Jinfeng Rao,
+Sharan Narang, Vinh Q Tran, Dani Yogatama, and Donald Metzler. Scaling laws vs model
+architectures: How does inductive bias influence scaling? arXiv preprint arXiv:2207.10551 ,
+2022.
+18
+[50] Sachin Goyal, Pratyush Maini, Zachary C Lipton, Aditi Raghunathan, and J Zico Kolter.
+Scaling laws for data filtering–data curation cannot be compute agnostic. In Proceedings of
+the IEEE/CVF Conference on Computer Vision and Pattern Recognition , pages 22702–22711,
+2024.
+19
+Appendix: Scaling Laws for Robust Comparison of Open
+Foundation Language-Vision Models and Datasets
+A Estimated parameters for scaling law fits
+To complement main results for scaling law based comparison of CLIP and MaMMUT (Sec. 3.1,
+Fig. 1, 2), we provide exact numbers of scaling law fits for both openCLIP and openMaMMUT
+measurements on zero shot IN1K classification and MS-COCO retrieval downstream tasks (Tab. 5a).
+Estimated values of exponents in power laws alone do not tell which models are more scalable, as
+we use here the functional form with additive terms for both irreducible error and non-zero random
+model performance (Eq. 1). Apart from plot visualization attesting Mammut stronger scalability than
+CLIP (Fig. 1, 2), scalability can be also compared via computing derivatives of the obtained fit in
+selected compute points. Derivatives that have larger absolute values stand for larger slope (bigger
+rate of decrease) and thus indicate stronger scalability. In Tab. 5b we show derivatives computed for
+scaling law fits, obtaining larger derivatives for openMaMMUT than for openCLIP, confirming again
+stronger scalability for MaMMUT over CLIP.
+B More details on scaling law derivation experiments
+Compute budget and energy consumption for the experiments. In Tab. 7, we provide overview
+over the GPU hours and energy spent for scaling law derivation experiments. We provide separate
+calculation for different learning rate schedule types (cosine, constant learning rate and constant
+learning rate + cooldown), for different datasets (Re-LAION-1.4B and DataComp-1.4B) and for
+different GPU types (A100 and H100). Large fraction of resources was spent for reference cosine
+schedule based scaling law derivation on DataComp-1.4B. We see that despite higher density of
+possible measurements, const based schedules use substantially less compute.
+Detailed versions of scaling law plots. In the more detailed versions of scaling law plots (Fig. 15
+and 16) we see the separate scaling curves for each model size (cooler colors indicate smaller models).
+Thebigger models require larger sample seen scale to unfold their performance advantage, with
+the performance lagging behind smaller scale models on same smaller compute scale, where larger
+models suffer from sample seen scale bottleneck. On the other hand, for the higher compute and
+ModelImageNet-1k MS-COCO Retrieval
+Ac Bc αc Ec Ac Bc αc Ec
+openCLIP 57.862 18.391 -0.227 0.111 53.913 18.413 -0.230 0.216
+openMaMMUT 79.970 19.111 -0.233 0.076 119.751 19.122 -0.263 0.212
+(a) Fitted scaling law parameters (Ac, Bc, αc, Ec)for error rate on 0-shot ImageNet-1k classification and
+MS-COCO retrieval tasks, rounded to three decimal places for models trained on DataComp-1.4B.
+C0GFLOPs IN-1k Err. Rate |dL(C0)/dC| COCO R@5 Err. Rate |dL(C0)/dC|
+CLIP
+5.00e+10 9.85e-13 8.44e-13
+1.00e+11 4.21e-13 3.60e-13
+5.00e+11 5.86e-14 4.95e-14
+Average: IN-1k: 4.882e-13, COCO: 4.177e-13
+MaMMUT
+5.00e+10 1.17e-12 9.65e-13
+1.00e+11 4.92e-13 4.03e-13
+5.00e+11 6.54e-14 5.28e-14
+Average: IN-1k: 5.758e-13, COCO: 4.702e-13
+(b) Numerical values of derivatives of fitted functions with respect to compute, in points 5·1010,1·1011,5·1011
+GFLOPs for both ImageNet-1k error rate and COCO retrieval error rate (1-R@5). MaMMUT consistently
+exhibits higher values of |dL(C0)/dC|which corresponds to higher decrease rate and stronger scalability.
+Table 5: Estimated parameters for main scaling law fits for 0-shot ImageNet-1k classification and
+MS-COCO retrieval, used for openCLIP and openMaMMUT comparison in Fig. 1
+20
+ModelImageNet-1k MS-COCO Retrieval
+Ac Bc αc Ec Ac Bc αc Ec
+openCLIP 14.769 16.725 -0.168 0.121 6.686 16.209 -0.123 0.089
+openMaMMUT 1850.286 20.521 -0.379 0.198 634.190 20.256 -0.335 0.249
+Table 6: Fitted scaling law parameters (Ac, Bc, αc, Ec)for error rate on 0-shot ImageNet-1k clas-
+sification and MS-COCO retrieval tasks, rounded to three decimal places for models trained on
+DataComp-1.4B with constant learning rate scheduler.
+LR Scheduler GPU Dataset MWh GPU Hours
+NVIDIA A100
+cosine NVIDIA-A100 DataComp-1.4B 2.59e+05 1.03e+06
+const-cooldown NVIDIA-A100 DataComp-1.4B 1.43e+05 5.72e+05
+const NVIDIA-A100 DataComp-1.4B 9.30e+04 3.72e+05
+cosine NVIDIA-A100 Re-LAION-1.4B 3.91e+04 1.56e+05
+const-cooldown NVIDIA-A100 Re-LAION-1.4B 1.70e+04 6.79e+04
+const NVIDIA-A100 Re-LAION-1.4B 4.61e+03 1.84e+04
+A100 subtotal: 5.56e+05 2.22e+06
+NVIDIA H100
+cosine NVIDIA-H100 DataComp-1.4B 2.09e+04 2.98e+04
+cosine NVIDIA-H100 Re-LAION-1.4B 1.06e+04 1.52e+04
+H100 subtotal: 3.15e+04 4.50e+04
+Total: 5.87e+05 2.27e+06
+Table 7: Total GPU compute and energy consumption for scaling law derivation experiments.
+samples seen scales, smaller models tend to saturate , indicating a bottleneck in model number of
+parameters.
+C Evaluating scaling law fit quality
+To validate our scaling law fits, we use a threshold Cthreshold to up which we take the data for the fit.
+We compute RMSE for the held-out points to get a measure of how good each fit is. We compare two
+Cthreshold values (see Tab. 8 and Fig. 17 for DataComp-1.4B dataset). We see that both RMSE and
+uncertainty (the width of the confidence intervals) decreases as we take more the more points for the
+fit.
+We also compare different functional forms that can be used to fit the data: model with double
+saturation ( L(C) =Ac·(C+Bc)−αc+Ec) and without a term for irreducible error Ec:
+L(C) =Ac·(C+Bc)−αc(3)
+We choose first Cthreshold = 2.5·1011GFLOPs and the second Cthreshold = 5·1011GFLOPs. As we
+see from Tab. 8 and Tab. 9 for both values of Cthreshold double saturation form (Eq. 1) has consistently
+lower RMSE than the function without irreducible error. RMSE on held out points provides thus a
+way to select among various scaling law fits the candidate that provides better prediction accuracy for
+unseen scales, which in our case is the fit obtained via double saturation functional form (Eq. 1).
+We see that the same trend of reducing confidence intervals and thus reducing uncertainty of the
+predictions when taking more points for the scaling law fit holds also for other tasks like MS-
+COCO image retrieval and other pre-training dataset Re-LAION-1.4B (see Fig. 17 and Fig. 18
+for comparison between ImageNet-1k classification and MS-COCO retrieval and Figs. 19, 20 for
+Re-LAION-1.4B).
+When comparing predictions with actually measured downstream task performance, we see that
+accuracy for the held-out points is high (Tab. 8). For instance, we measure for 3B samples seen scale
+on held-out points for openMaMMUT ViT L-14 zero-shot IN1K 0.784, with prediction 0.777 and 95%
+confidence interval (0.771, 0.783), and for openMaMMUT ViT H-14 0.795, with prediction 0.801
+21
+107108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+ViT-S-14
+ViT-S-16
+ViT-S-32
+ViT-M-16
+ViT-M-32
+ViT-B-14
+ViT-B-16-text-plus
+ViT-B-32
+ViT-L-14
+ViT-L-16
+ViT-L-32
+ViT-H-14
+ViT-H-16
+ViT-H-32
+CLIP: 57.86*(x+exp(18.39))0.227+0.11
+Figure 15: Detailed version of the scaling law fit for ImageNet 0-shot classification error rate
+for DataComp-1.4B for openCLIP. Cooler colors indicate smaller models. Bigger models are
+bottlenecked by samples seen scale (require larger samples seen than the smaller ones) and smaller
+models saturate with increased data and compute scale (over-training regime). Pareto front is
+composed by taking for each compute budget the points corresponding to models reaching minimal
+error rate for the given compute. Fit is performed through points on Pareto front.
+108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+mammut_ViT-S-14
+mammut_ViT-S-16
+mammut_ViT-S-32
+mammut_ViT-M-14
+mammut_ViT-M-16
+mammut_ViT-M-32
+mammut_ViT-B-14
+mammut_ViT-B-16
+mammut_ViT-B-32
+mammut_ViT-L-14
+mammut_ViT-L-16
+mammut_ViT-L-32
+mammut_ViT-H-14
+mammut_ViT-H-16
+mammut_ViT-H-32
+MAMMUT: 125.36*(x+exp(19.29))0.256+0.10
+Figure 16: Detailed version of the scaling law fit for ImageNet 0-shot classification error rate
+for DataComp-1.4B for OpenMaMMUT. Cooler colors indicate smaller models. Bigger models
+are bottlenecked by samples seen scale (require larger samples seen than the smaller ones) and
+smaller models saturate with increased data and compute scale (overtraining regime). Pareto front is
+composed by taking for each compute budget the points corresponding to models reaching minimal
+error rate for the given compute. Fit is performed through points on Pareto front.
+22
+107108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 81.05*(x+exp(18.49))0.246+0.14
+MAMMUT: 120.32*(x+exp(19.22))0.255+0.11
+(a) Scaling law fit for
+ImageNet 0-shot classification error rate for
+DataComp-1.4B
+(Cthreshold = 2.5·1011GFLOPs)
+107108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 63.34*(x+exp(18.42))0.232+0.12
+MAMMUT: 102.23*(x+exp(19.18))0.246+0.10
+(b) Scaling law fit for
+ImageNet 0-shot classification error rate
+for DataComp-1.4B using more points ( Cthreshold =
+5·1011GFLOPs)
+Figure 17: Comparison of the fit quality for ImageNet-1k 0-shot classification error rate for open-
+MaMMUT and openCLIP if we take less points for the fit in (a) vs. more in (b), for models trained on
+DataComp-1.4B. The uncertainty of the fit becomes smaller (indicated by the width of bands around
+each curve).
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 57.46*(x+exp(18.43))0.234+0.22
+MAMMUT: 228.63*(x+exp(19.26))0.297+0.25
+(a) Scaling law fit for
+MS-COCO image retrieval error rate (1-Recall@5)
+for DataComp-1.4B
+(Cthreshold = 2.5·1011GFLOPs)
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 58.58*(x+exp(18.44))0.235+0.22
+MAMMUT: 174.92*(x+exp(19.21))0.283+0.23
+(b) Scaling law fit for
+MS-COCO image retrievat error rate (1-Recall@5)
+for DataComp-1.4B using more points
+(Cthreshold = 5·1011GFLOPs)
+Figure 18: Comparison of the fit quality for MS-COCO image retrieval error rate for openMaMMUT
+and openCLIP if we take less points for the fit in (a) vs. more in (b), for models trained on DataComp-
+1.4B. The uncertainty of the fit becomes smaller (indicated by the width of bands around each curve).
+23
+107108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 81.05*(x+exp(18.49))0.246+0.14
+MAMMUT: 120.32*(x+exp(19.22))0.255+0.11
+(a) Scaling law fit for
+ImageNet 0-shot classification Error rate
+for Re-LAION-1.4B
+(Cthreshold = 2.5·1011GFLOPs)
+107108109101010111012
+Compute C [GFLOPs]100
+2×101
+3×101
+4×101
+6×101
+ImageNet1k 0-shot [Error Rate]
+CLIP: 63.34*(x+exp(18.42))0.232+0.12
+MAMMUT: 102.23*(x+exp(19.18))0.246+0.10
+(b) Scaling law fit for
+ImageNet 0-shot classification Error rate
+for Re-LAION-1.4B using more points
+(Cthreshold = 5·1011GFLOPs)
+Figure 19: Comparison of the fit quality for ImageNet-1k 0-shot classification error rate for open-
+MaMMUT and openCLIP if we take less points for the fit in (a) vs. more in (b), for models trained
+on Re-LAION-1.4B. The uncertainty of the fit becomes smaller (indicated by the width of bands
+around each curve).
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 57.46*(x+exp(18.43))0.234+0.22
+MAMMUT: 228.63*(x+exp(19.26))0.297+0.25
+(a) Scaling law fit for
+MS-COCO image retrieval error rate (1-Recall@5)
+for Re-LAION-1.4B
+(Cthreshold = 2.5·1011GFLOPs)
+107108109101010111012
+Compute C [GFLOPs]100
+3×101
+4×101
+6×101
+MSCOCO Image Retrival R@5 [Error Rate]
+CLIP: 58.58*(x+exp(18.44))0.235+0.22
+MAMMUT: 174.92*(x+exp(19.21))0.283+0.23
+(b) Scaling law fit for
+MS-COCO image retrieval error rate (1-Recall@5)
+for Re-LAION-1.4B
+(Cthreshold = 5·1011GFLOPs)
+Figure 20: Comparison of the fit quality for MS-COCO image retrieval error rate for openMaMMUT
+and openCLIP if we take less points for the fit in (a) vs. more in (b), for models trained on Re-
+LAION-1.4B. The uncertainty of the fit becomes smaller (indicated by the width of bands around
+each curve).
+24
+and 95% CI of (0.793, 0.809). Similar accuracy is observed for openCLIP, with actual measurements
+falling within predicted confidence intervals. The derived scaling laws provide thus solid ground
+for comparison on unseen scales that have low amount of repetitions (less than 3x in case of 3B
+samples seen scale when training on DataComp-1.4B or Re-LAION-1.4).
+As already discussed in Sec. 3.7, the prediction for performance of MaMMUT L-14 on the larger
+12.8B samples seen scale (Tab. 1, zero-shot IN1K 0.820, 95% CI (0.815, 0.826)) is therefore
+only made for low repetition scenario, and to validate it, dataset size larger than currently used
+1.4B samples (which gives around 9x repetitions for 12.8B samples seen scale) is required. The
+measured 0.803 for openMaMMUT L-14 on 12.8B (Tab. 3) is thus expectedly below the prediction,
+as performance is diminished due to high amount of repetitions, in line with observations by previous
+works [41, 50].
+Model Samples Seen GFLOPsIN1k
+0-shot accPredicted IN1k
+0-shot acc (95% CI)Predicted (more points) IN1k
+0-shot acc (95% CI)
+CLIP
+ViT-L-16 3.07e+9 4.07e+11 0.761 0.747 (0.738, 0.755) –
+ViT-L-14 3.07e+9 5.18e+11 0.766 0.753 (0.744, 0.762) 0.759 (0.751, 0.766)
+ViT-H-14 3.07e+9 1.14e+12 0.784 0.773 (0.761, 0.784) 0.779 (0.770, 0.789)
+RMSE: 1.26e-02 RMSE (more points): 5.90e-03
+MaMMUT
+mammut-ViT-L-14 1.28e+9 2.59e+11 0.749 0.743 (0.737, 0.748) –
+mammut-ViT-L-14 3.07e+9 6.22e+11 0.784 0.773 (0.765, 0.781) 0.777 (0.771, 0.783)
+mammut-ViT-H-14 3.07e+9 1.43e+12 0.794 0.797 (0.787, 0.807) 0.801 (0.793, 0.809)
+RMSE: 7.57e-03 RMSE (more points): 7.57e-03
+Table 8: Predictions for different values of Cthreshold for the functional form with double saturation
+(Eq. 1). Scaling law derivation on DataComp-1.4B. The last column shows updated predictions made
+after additional data points. Both confidence interval and RMSE decrease as we take more points.
+RMSE is consistently lower than RMSE measured for functional form without irreducible error (Tab.
+9).
+Model Samples Seen GFLOPsIN1k
+0-shot accPredicted IN1k
+0-shot acc (95% CI)Predicted (more points) IN1k
+0-shot acc (95% CI)
+CLIP
+ViT-L-16 3.07e+9 4.07e+11 0.761 0.769 (0.764, 0.773) –
+ViT-L-14 3.07e+9 5.18e+11 0.766 0.778 (0.774, 0.783) 0.777 (0.773, 0.782)
+ViT-H-14 3.07e+9 1.14e+12 0.784 0.806 (0.802, 0.811) 0.805 (0.801, 0.809)
+RMSE: 1.55e-02 RMSE (more points): 1.72e-02
+MaMMUT
+mammut-ViT-L-14 1.28e+9 2.59e+11 0.749 0.757 (0.754, 0.760) –
+mammut-ViT-L-14 3.07e+9 6.22e+11 0.784 0.795 (0.792, 0.798) 0.794 (0.791, 0.796)
+mammut-ViT-H-14 3.07e+9 1.43e+12 0.794 0.825 (0.822, 0.828) 0.824 (0.822, 0.827)
+RMSE: 1.98e-02 RMSE (more points): 2.26e-02
+Table 9: Predictions for different values of Cthreshold for the functional form without irreducible error
+(Eq. 3). Scaling law derivation on DataComp-1.4B. The last column shows updated predictions made
+after additional data points. Both confidence interval and RMSE decrease as we take more points.
+RMSE is consistently higher than RMSE measured for functional form with irreducible error (Tab.
+8).
+D Additional training details
+In the Tab. 11 and 10 we provide training hyperparameters for all models and sample seen scales that
+were used for scaling law fits (i.e. models that are located on the Pareto frontier) for openMaMMUT
+and openCLIP respectively. Tab. 12 provides overview of model architectures parameters used for
+training openCLIP and openMammut. For the hyperparameters used for training openMaMMUT-L-
+14, the strongest model obtained following scaling law based comparisons done in this study, see Tab.
+4.
+25
+Model Samples Seen Warmup Global Batch Size Learning Rate
+mammut-ViT-S-32 1.28e+06 1000 512 1.00e-03
+mammut-ViT-S-32 1.28e+06 1500 512 5.00e-04
+mammut-ViT-S-16 1.28e+06 1000 512 5.00e-04
+mammut-ViT-S-32 3.07e+06 4000 512 5.00e-04
+mammut-ViT-S-16 3.07e+06 4000 512 1.00e-03
+mammut-ViT-S-32 6.40e+06 4000 1024 1.00e-03
+mammut-ViT-S-32 1.28e+07 4000 2048 2.00e-03
+mammut-ViT-S-16 1.28e+07 3000 2048 2.00e-03
+mammut-ViT-S-32 3.07e+07 4000 4096 2.00e-03
+mammut-ViT-S-16 3.07e+07 3000 4096 2.00e-03
+mammut-ViT-S-32 6.40e+07 4000 4096 2.00e-03
+mammut-ViT-S-16 6.40e+07 4000 4096 1.50e-03
+mammut-ViT-S-32 1.28e+08 4000 8192 2.00e-03
+mammut-ViT-S-14 1.28e+08 4000 8192 2.00e-03
+mammut-ViT-M-16 1.28e+08 4000 8192 2.00e-03
+mammut-ViT-S-14 3.07e+08 4000 16384 2.00e-03
+mammut-ViT-M-16 3.07e+08 4000 16384 2.00e-03
+mammut-ViT-S-14 6.40e+08 4000 16384 1.50e-03
+mammut-ViT-B-16 3.07e+08 4000 16384 2.00e-03
+mammut-ViT-B-32 1.28e+09 4000 16384 2.00e-03
+mammut-ViT-B-16 6.40e+08 4000 32768 2.00e-03
+mammut-ViT-B-14 1.28e+09 4000 90624 2.00e-03
+mammut-ViT-L-16 6.40e+08 6000 45056 2.00e-03
+mammut-ViT-L-14 6.40e+08 6000 45056 2.00e-03
+mammut-ViT-L-14 1.28e+09 4000 90624 2.00e-03
+mammut-ViT-L-16 3.07e+09 4000 91136 2.00e-03
+mammut-ViT-L-14 3.07e+09 4000 91136 2.00e-03
+Table 10: Hyperparameters for MaMMUT models trained on DataComp-1.4B that are located on the
+Pareto frontier
+E More details on fine-tuning for segmentation and scaling laws
+Following prior work on how to benchmark vision foundation models for semantic segmentation [ 35],
+we evaluate CLIP and MaMMUT on semantic segmentation by fine-tuning them end-to-end using a
+linear decoder on ADE20K [ 34]. Regardless of the patch size used during pre-training, we interpolate
+the patch size of all models to 14×14, to ensure a fair comparison. We use an image input size of
+224×224and thus interpolate the positional embedding to 16 ×16. Hyperparameters used for training
+are consistent with [ 35], except the use of a linear learning rate warmup of 1500 steps, an epoch-
+based schedule of 31 epochs, and a batch size of 16 without gradient accumulation, following [ 36].
+We fine-tune pre-trained models up to and including ViT-L and 3B samples seen, with different
+pre-training hyperparameters. We evaluate using a sliding window approach, again following [35].
+Fig. 21 and Fig. 22 show the fitted scaling laws for CLIP and MaMMUT, respectively. Tab. 13 shows
+the corresponding estimated scaling law fit parameters.
+F Broader impact
+This paper presents work whose goal is to advance the field of machine learning. While there are
+many potential societal consequences of this work, as of any work that targets scientific progress, we
+would like to emphasize some we consider important. Foundation models and datasets necessary for
+their creation became essential artefacts in basic machine learning research. On the one hand, they
+enable systematic studies of transferable learning and generalization. To ensure the reproducibility
+of such studies by various independent parties, to draw verifiable comparisons between those and
+to make collaborative, independently validated progress, models and datasets have to be open, and
+robust comparison procedures have to be designed. On the other hand, foundation models became
+26
+Model Samples Seen Warmup Global Batch Size Learning Rate
+ViT-S-32 1.28e+06 1500 512 5.00e-04
+ViT-S-16 1.28e+06 1500 512 5.00e-04
+ViT-S-16 1.28e+06 1500 512 2.00e-03
+ViT-S-32 3.07e+06 1500 1024 5.00e-04
+ViT-S-32 6.40e+06 4000 1024 1.00e-03
+ViT-S-32 1.28e+07 4000 2048 1.00e-03
+ViT-M-32 1.28e+07 3000 2048 1.00e-03
+ViT-S-32 3.07e+07 4000 4096 2.00e-03
+ViT-S-32 6.40e+07 4000 4096 2.00e-03
+ViT-M-32 6.40e+07 10000 4096 1.00e-03
+ViT-S-32 1.28e+08 6000 8192 2.00e-03
+ViT-S-16 1.28e+08 6000 8192 2.00e-03
+ViT-S-32 3.07e+08 8000 16384 2.00e-03
+ViT-S-32 6.40e+08 4000 16384 2.00e-03
+ViT-S-14 3.07e+08 4000 16384 2.00e-03
+ViT-M-32 6.40e+08 6000 32800 2.00e-03
+ViT-B-32 1.28e+09 15000 16384 1.00e-03
+ViT-L-32 6.40e+08 4000 45056 2.00e-03
+ViT-B-16-text-plus 6.40e+08 6000 32768 2.00e-03
+ViT-L-32 1.28e+09 4000 90624 4.00e-03
+ViT-L-16 6.40e+08 4000 45056 2.00e-03
+ViT-L-32 3.07e+09 4000 91136 4.00e-03
+ViT-L-14 1.28e+09 4000 90624 4.00e-03
+ViT-L-16 3.07e+09 4000 91136 4.00e-03
+ViT-L-14 3.07e+09 4000 91136 4.00e-03
+Table 11: Hyperparameters for CLIP models trained on DataComp-1.4B that are located on the Pareto
+frontier.
+107108109101010111012
+Compute C [GFLOPs]6×101
+7×101
+8×101
+9×101
+ADE20K Semantic Segmentation [Error Rate]
+ViT-S-14
+ViT-S-16
+ViT-S-32
+ViT-M-16
+ViT-M-32
+ViT-B-14
+ViT-B-16-text-plus
+ViT-B-32
+ViT-L-14
+ViT-L-16
+ViT-L-32
+CLIP: 17.93*(x+exp(17.49))0.208+0.47
+Figure 21: Detailed scaling law for downstream semantic segmentation performance of openCLIP
+pre-trained on DataComp-1.4B and fine-tuned on ADE20K. Error rate (1 – mIoU).
+indispensable building blocks of various systems for problem solving. Claims behind the capabilities
+of those systems to be rooted in certain conditions of the learning procedure and datasets used
+to obtain the models are made, often without doing proper comparison of compute involved in
+training of different models or without controlling for various conditions in the learning procedure.
+Especially the datasets used in the large industry labs are still often closed, so that it is impossible
+to do fair model comparison on same data if studying an alternative method. This makes claims
+27
+Name Width Emb Depth Params (M) GFLOPs
+ViT-S-32 384/384 384 12/12 63.09 5.51
+mammut-ViT-S-32 384/384 384 12/12 85.62 13.91
+ViT-S-16 384/384 384 12/12 62.26 11.75
+mammut-ViT-S-16 384/384 384 12/12 84.79 20.72
+ViT-S-14 384/384 384 12/12 62.21 14.3
+mammut-ViT-S-14 384/384 384 12/12 84.74 23.5
+ViT-M-32 512/512 512 12/12 103.12 9.74
+mammut-ViT-M-32 512/512 512 12/12 134.73 22.1
+ViT-M-16 512/512 512 12/12 102.02 20.84
+mammut-ViT-M-16 512/512 512 12/12 133.63 34.2
+ViT-M-14 512/512 512 12/12 101.95 25.37
+mammut-ViT-M-14 512/512 512 12/12 133.57 39.14
+ViT-B-32 768/512 512 12/12 151.28 14.54
+mammut-ViT-B-32 768/512 512 12/12 183.02 26.91
+ViT-B-16 768/512 512 12/12 149.62 39.51
+ViT-B-16-text-plus 768/768 768 12/12 210.04 46.78
+mammut-ViT-B-16 768/512 512 12/12 290.52 79.7
+ViT-B-14 768/512 512 12/12 149.53 49.7
+mammut-ViT-B-14 768/512 512 12/12 181.27 63.54
+ViT-L-32 1024/768 768 24/12 429.95 43.59
+mammut-ViT-L-32 1024/768 768 24/12 510.63 74.28
+ViT-L-16 1024/768 768 24/12 427.74 132.37
+mammut-ViT-L-16 1024/768 768 24/12 508.42 165.37
+ViT-L-14 1024/768 768 24/12 427.62 168.61
+mammut-ViT-L-14 1024/768 768 24/12 508.29 202.56
+ViT-H-32 1280/1024 1024 32/24 989.02 109.81
+mammut-ViT-H-32 1280/1024 1024 32/24 1191.06 192.97
+ViT-H-16 1280/1024 1024 32/24 986.26 294.78
+mammut-ViT-H-16 1280/1024 1024 32/24 1188.3 385.72
+ViT-H-14 1280/1024 1024 32/24 986.11 370.28
+mammut-ViT-H-14 1280/1024 1024 32/24 1188.14 464.39
+Table 12: Hyper-parameters of architectures we consider. Width refers to encoder width, Emb refers
+to embedding size, Depth refers to number of layers, Params refer to the number of parameters in
+millions, and GFLOPs refer to total GFLOPs per forward pass. Entries in the form of A / B denote
+image and text parameters respectively. There are more parameters in MaMMUT models because of
+the additional cross-attention layers.
+Ac Bc αc Ec
+CLIP 18.407549 17.577295 -0.209187 0.468456
+MaMMUT 352.152176 18.759619 -0.356718 0.497617
+Table 13: Fitted scaling law parameters (Ac, Bc, αc, Ec)for segmentation error rate.
+hard to validate and impairs guided progress in improving foundation models and datasets. Our
+work operates with whole research pipeline being fully open and reproducible, which includes open
+datasets, open-source training and evaluation code and open weights models, including intermediate
+checkpoints and training logs. Our comparison is done involving full scaling law derivation, instead
+of reporting performance on few selected reference points. This sets standards for reproducibility,
+transparency and robust comparison to check the claims in the field that generates important artefacts
+that are getting used in increasingly many scenarios that directly impact our society. We consider this
+work thus an important catalyst for trust into open foundation models that have undergone robust
+comparison procedure, resulting in accurate, reproducible claims that can be validated by many
+independent parties and in which the society and public can develop better trust.
+28
+108109101010111012
+Compute C [GFLOPs]5×101
+6×101
+7×101
+8×101
+9×101
+ADE20K Semantic Segmentation [Error Rate]
+mammut_ViT-S-14
+mammut_ViT-S-16
+mammut_ViT-S-32
+mammut_ViT-M-16
+mammut_ViT-M-32
+mammut_ViT-B-14
+mammut_ViT-B-16
+mammut_ViT-B-32
+mammut_ViT-L-14
+mammut_ViT-L-16
+mammut_ViT-L-32
+MAMMUT: 331.17*(x+exp(18.73))0.354+0.50
+Figure 22: Detailed scaling law for downstream semantic segmentation performance of openMaM-
+MUT pre-trained on DataComp-1.4B and fine-tuned on ADE20K. Error rate (1 – mIoU).
+G Author contributions
+•Marianna Nezhurina : established major part of scaling law fitting procedures. Performed
+analysis of scaling law fit quality, derived predictions and confidence intervals. Conducted
+major part of data analysis. Performed initial training experiments with openCLIP and
+openMaMMUT. Established environments for experiments across various supercomputers.
+Supported compute resource acquisition. Established infrastructure for distributed dataset
+acquisition via Ray. Obtained Re-LAION and part of DFN dataset. Co-organized automated
+experiments data collection and analysis. Wrote the manuscript.
+•Tomer Porian : co-designed and performed const lr schedule scaling law derivation ex-
+periments. Extended automated experiments execution for const lr schedule experiments.
+Collected and analyzed data, provided further input for scaling law fitting procedures.
+Co-wrote the manuscript.
+•Tommie Kerssies : fine-tuning experiments for dense prediction segmentation, evaluating
+segmentation via different modes, scaling law derivation for segmentation, data collection
+and analysis. Co-wrote the manuscript.
+•Giovanni Pucceti : openMaMMUT implementation in openCLIP, initial experiments with
+openCLIP and openMammut training. Initial co-design and implementation of automated
+experiments execution. Proof reading the manuscript.
+•Romain Beaumont Re-LAION safety maintenance, hash filtering and re-packaging.
+Toolsets for dataset download and composition. Proof reading the manuscript.
+•Mehdi Cherti : led the project, supported compute resource acquisition. Co-established
+environments for experiments across various supercomputers. Obtained DataComp, DFN
+and part of Re-LAION dataset. Designed and implemented automated experiments execution
+and evaluation. Wrote procedure for const lr schedule experiments. Conducted scaling
+law derivation experiments (DataComp, Re-LAION, DFN; openMammut, openCLIP, Cap).
+Designed and implemented evaluation. Organized automated experiments data collection
+and analysis. Collected and analysed the experimental data. Wrote the manuscript.
+•Jenia Jitsev : led and coordinated the project, acquired compute resources. Organized data
+transfer (DataComp, Re-LAION) across the supercomputers. Co-established environments
+for experiments across various supercomputers. Co-designed automated experiments exe-
+cution. Defined, designed and conducted scaling law derivation experiments (DataComp,
+Re-LAION, DFN; openMammut, openCLIP, CoCa, SigLIP). Collected and analysed the
+experimental data. Trained openMammut-L-14 on 12.8B of DataComp-1.4B, following the
+scaling law predictions. Led manuscript writing, wrote the manuscript.
+29


### PR DESCRIPTION
## Summary
- add article about scaling laws for CLIP and MaMMUT

## Testing
- `pip install requests PyPDF2`
- `python3 pdf_to_text.py https://arxiv.org/pdf/2506.04598 temp.txt`


------
https://chatgpt.com/codex/tasks/task_e_68475796638c832e9a3520973c7b1c60