### PR TITLE
Fix Markdown media syntax and add tests

### DIFF
--- a/2025/06/qiita.com/2025-06-09_445db2d542f44f9a3e4c.md
+++ b/2025/06/qiita.com/2025-06-09_445db2d542f44f9a3e4c.md
@@ -13,9 +13,7 @@ MastraとMCP(Playwright連携ツール)をNext.jsで使うと、ツールが共�
 
 ## 本文
 
-[![](https://qiita-user-profile-images.imgix.net/https%3A%2F%2Fs3-ap-northeast-1.amazonaws.com%2Fqiita-image-store%2F0%2F41574%2F4ef6383293ba9e6cefbb98fc8c65bd4cf6cb38a2%2Fx_large.png%3F1595642985?ixlib=rb-4.0.0&auto=compress%2Cformat&lossless=0&w=48&s=9e1f48e63c0cf58dfc3e42261ec49aa4)
-
-@moritalous](/moritalous)
+[![](https://qiita-user-profile-images.imgix.net/https%3A%2F%2Fs3-ap-northeast-1.amazonaws.com%2Fqiita-image-store%2F0%2F41574%2F4ef6383293ba9e6cefbb98fc8c65bd4cf6cb38a2%2Fx_large.png%3F1595642985?ixlib=rb-4.0.0&auto=compress%2Cformat&lossless=0&w=48&s=9e1f48e63c0cf58dfc3e42261ec49aa4)](/moritalous)
 
 Next.js + Mastra環境でMCPを使うのは難しい。。
 ================================

--- a/2025/06/qiita.com/2025-06-09_acaf251a2f6bf984a3df.md
+++ b/2025/06/qiita.com/2025-06-09_acaf251a2f6bf984a3df.md
@@ -13,10 +13,7 @@ GitHub Copilot Chatの **Agent モード** で 90年代風の静的サイトを�
 
 ## 本文
 
-[![](https://qiita-user-profile-images.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F24609%2Fprofile-images%2F1653902413?ixlib=rb-4.0.0&auto=compress%2Cformat&lossless=0&w=48&s=379fc42c554f1b95c7c206efe12f5e13)
-
-@chomado(Madoka Chiyoda)](/chomado)
-
+[![](https://qiita-user-profile-images.imgix.net/https%3A%2F%2Fqiita-image-store.s3.ap-northeast-1.amazonaws.com%2F0%2F24609%2Fprofile-images%2F1653902413?ixlib=rb-4.0.0&auto=compress%2Cformat&lossless=0&w=48&s=379fc42c554f1b95c7c206efe12f5e13)](/chomado)
 #意識低いAICodingチュートリアル #01 インターネット老人会のサイトを作ろう [GitHub Copilot Agent mode 版]
 =========================================================================
 

--- a/2025/06/www.apple.com/2025-06-09_apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices.md
+++ b/2025/06/www.apple.com/2025-06-09_apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices.md
@@ -64,8 +64,7 @@ Apple Intelligenceの機能は年末までに、デンマーク語、オラン�
 
 ジェン文字とImage Playgroundは、ユーザーにさらに多くの自己表現の方法を提供します。テキストによる説明をジェン文字に変換するだけでなく、絵文字を取り入れ、それらを説明と組み合わせることによって、新しいものを作り出せるようになります。ジェン文字やImage Playgroundを使用して、家族や友人からインスピレーションを得た画像を作成する際、ユーザーは表現方法を変更したり、例えば友人の最新の見た目に合わせてヘアスタイルを変えるなど、個人の特徴を調整したりできます。
 
-[![
-](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-genmoji-mix/posters/Apple-WWDC25-Apple-Intelligence-Genmoji-mix-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-genmoji-mix/large_2x.mp4)
+[![動画](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-genmoji-mix/posters/Apple-WWDC25-Apple-Intelligence-Genmoji-mix-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-genmoji-mix/large_2x.mp4)
 
 ジェン文字の機能強化により、ユーザーは絵文字を取り入れ、説明と組み合わせることによって新しいものを作り出すオプションを活用し、より多くの方法で自己表現できるようになります。
 
@@ -80,22 +79,19 @@ Image Playgroundでは、ChatGPTによって油絵風やベクターアートな
 
 Apple Intelligenceを基盤とするビジュアルインテリジェンスがユーザーのiPhoneの画面に拡張され、ユーザーはあらゆるアプリで、画面上に表示しているものを検索し操作できます。
 
-[![
-](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-etsy/posters/Apple-WWDC25-Apple-Intelligence-Visual-Intelligence-with-Etsy-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-etsy/large_2x.mp4)
+[![動画](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-etsy/posters/Apple-WWDC25-Apple-Intelligence-Visual-Intelligence-with-Etsy-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-etsy/large_2x.mp4)
 
 Apple Intelligenceのアップデートで、ビジュアルインテリジェンスがユーザーのiPhoneの画面上に表示されているコンテンツに拡張され、GoogleやEtsyなどの対応アプリを使って似たようなものを探すといった操作が可能になります。
 
 ビジュアルインテリジェンスはすでに、ユーザーがiPhoneのカメラを使用して周囲の対象物や場所について学ぶのに役立っていますが、これからはiPhoneの画面上に表示されているものについて、より多くのことを、より速く実行できるようになります。ユーザーは画面上で見ているものについてChatGPTに質問して詳しい情報を得たり、GoogleやEtsyなどの対応アプリで検索して類似の画像や製品を見つけたりできます。例えばランプなど、特に興味を惹かれるものが表示されている場合、ユーザーはそれをハイライトし、同じものや似たようなものをオンラインで検索することができます。
 
-[![
-](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-chatgpt/posters/Apple-WWDC25-Apple-Intelligence-Visual-Intelligence-with-ChatGPT-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-chatgpt/large_2x.mp4)
+[![動画](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-chatgpt/posters/Apple-WWDC25-Apple-Intelligence-Visual-Intelligence-with-ChatGPT-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-chatgpt/large_2x.mp4)
 
 ビジュアルインテリジェンスによって、ユーザーは特定の対象物についての詳細をChatGPTに質問することができます。
 
 ビジュアルインテリジェンスは、イベントが表示されていることを認識してカレンダーへの追加を提案し4、Apple Intelligenceが関連するデータを抽出してイベントを作成します。
 
-[![
-](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-add-to-calendar/posters/Apple-WWDC25-Apple-Intelligence-Visual-Intelligence-add-to-Calendar-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-add-to-calendar/large_2x.mp4)
+[![動画](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-add-to-calendar/posters/Apple-WWDC25-Apple-Intelligence-Visual-Intelligence-add-to-Calendar-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-add-to-calendar/large_2x.mp4)
 
 ビジュアルインテリジェンスは、イベントが表示されていることを認識してカレンダーへの追加を提案し、Apple Intelligenceが関連するデータを抽出してイベントを作成します。
 
@@ -110,8 +106,7 @@ Workout Buddyは、Apple Intelligenceを利用した、ほかに類を見ないA
 
 Workout Buddyは、Bluetoothヘッドフォンを接続したApple Watchで利用でき、Apple Intelligence対応のiPhoneが近くにあることが必要です。屋外および屋内のランニング、屋外および屋内のウォーキング、屋外のサイクリング、高強度インターバルトレーニング、機能的および従来型筋力トレーニングなど、人気の高いワークアウトの種類の一部において、まずは英語で利用できるようになります。
 
-[![
-](/newsroom/videos/2025/hls/06/watchOS-26/Web/US/posters/Apple-WWDC25-watchOS-26-Apple-Intelligence-Workout-Buddy-250609_571x321.jpg.large.jpg)](/newsroom/videos/2025/hls/06/watchOS-26/Web/US/apple-wwdc25-watchos-26-apple-intelligence-workout-buddy-250609_16x9.m3u8)
+[![動画](/newsroom/videos/2025/hls/06/watchOS-26/Web/US/posters/Apple-WWDC25-watchOS-26-Apple-Intelligence-Workout-Buddy-250609_571x321.jpg.large.jpg)](/newsroom/videos/2025/hls/06/watchOS-26/Web/US/apple-wwdc25-watchos-26-apple-intelligence-workout-buddy-250609_16x9.m3u8)
 
 Apple Watchに登場するWorkout Buddyは、Apple Intelligenceを利用した、ほかに類を見ないワークアウト体験で、ユーザーのワークアウトのデータと個人的なフィットネス履歴を取り込み、パーソナライズされた洞察を生成してモチベーションを高めます。
 
@@ -120,15 +115,13 @@ Apple Watchに登場するWorkout Buddyは、Apple Intelligenceを利用した�
 
 Appleは、Apple Intelligenceの中核にあるデバイス上の基盤モデルをどのアプリからでも直接利用できるようにしました。
 
-[![
-](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-kahoot/posters/Apple-WWDC25-Apple-Intelligence-on-device-Foundation-Model-framework-Kahoot-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-kahoot/large_2x.mp4)
+[![動画](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-kahoot/posters/Apple-WWDC25-Apple-Intelligence-on-device-Foundation-Model-framework-Kahoot-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-kahoot/large_2x.mp4)
 
 基盤モデルフレームワークにより、デベロッパはApple Intelligenceの中核にあるデバイス上の基盤モデルを直接利用できるようになり、パワフルかつ高速で、プライバシーが組み込まれ、ユーザーがオフラインの時にも使えるインテリジェンスにアクセスできます。
 
 基盤モデルフレームワークを利用すれば、アプリのデベロッパはApple Intelligenceをベースに、無料のAI推論を利用して、インテリジェントで、オフラインでも利用でき、プライバシーが保護される新たな体験をユーザーに提供できるようになります。例えば教育アプリなら、デバイス上のモデルを利用して、クラウドAPIの費用をかけることなく、ユーザーのメモをもとにパーソナライズされたクイズを作成でき、アウトドアアプリなら、ユーザーがオフラインの時にも使える自然な言葉づかいでの検索機能を追加できます。
 
-[![
-](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-alltrails/posters/Apple-WWDC25-Apple-Intelligence-on-device-Foundation-Model-framework_AllTrails-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-alltrails/large_2x.mp4)
+[![動画](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-alltrails/posters/Apple-WWDC25-Apple-Intelligence-on-device-Foundation-Model-framework_AllTrails-250609.jpg.large_2x.jpg)](/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-alltrails/large_2x.mp4)
 
 基盤モデルフレームワークはSwiftにネイティブ対応しているため、アプリのデベロッパはたった3行のコードでApple Intelligenceのモデルを簡単に利用できます。
 
@@ -362,32 +355,31 @@ Appleは1984年にMacintoshを登場させ、パーソナルテクノロジー�
 -------
 
 Apple Japan 広報部
-
-[japan\_press@apple.com](mailto:japan_press@apple.com)
+[japan_press@apple.com](mailto:japan_press@apple.com)
 
 最新のニュース
 -------
 
-[![](https://www.apple.com/newsroom/images/2025/06/apple-supercharges-its-tools-and-technologies-for-developers/tile/Apple-WWDC25-macOS-Tahoe-26-XCode-26-250609-lp.jpg.landing-regular.jpg)
+[![](https://www.apple.com/newsroom/images/2025/06/apple-supercharges-its-tools-and-technologies-for-developers/tile/Apple-WWDC25-macOS-Tahoe-26-XCode-26-250609-lp.jpg.landing-regular.jpg)](/jp/newsroom/2025/06/apple-supercharges-its-tools-and-technologies-for-developers/)
 
 プレスリリース
 
 ### Apple、デベロッパのためのツールとテクノロジーを強化
 
-2025 年 6 月 9 日](/jp/newsroom/2025/06/apple-supercharges-its-tools-and-technologies-for-developers/)
+2025 年 6 月 9 日
 
-[![](https://www.apple.com/newsroom/images/2025/06/airpods-now-more-versatile-with-studio-quality-audio-recording-and-camera-remote/tile/Apple-WWDC25-AirPods-hero-250609.jpg.landing-regular.jpg)
+[![](https://www.apple.com/newsroom/images/2025/06/airpods-now-more-versatile-with-studio-quality-audio-recording-and-camera-remote/tile/Apple-WWDC25-AirPods-hero-250609.jpg.landing-regular.jpg)](/jp/newsroom/2025/06/airpods-now-more-versatile-with-studio-quality-audio-recording-and-camera-remote/)
 
 クイックリーディング
 
 ### AirPodsがさらに多機能に
 
-2025 年 6 月 9 日](/jp/newsroom/2025/06/airpods-now-more-versatile-with-studio-quality-audio-recording-and-camera-remote/)
+2025 年 6 月 9 日
 
-[![](https://www.apple.com/newsroom/images/2025/06/visionos-26-introduces-powerful-new-spatial-experiences-for-apple-vision-pro/tile/Apple-WWDC25-visionOS-26-hero-250609-lp.jpg.landing-regular.jpg)
+[![](https://www.apple.com/newsroom/images/2025/06/visionos-26-introduces-powerful-new-spatial-experiences-for-apple-vision-pro/tile/Apple-WWDC25-visionOS-26-hero-250609-lp.jpg.landing-regular.jpg)](/jp/newsroom/2025/06/visionos-26-introduces-powerful-new-spatial-experiences-for-apple-vision-pro/)
 
 プレスリリース
 
 ### visionOS 26、Apple Vision Proにパワフルな新しい空間体験を導入
 
-2025 年 6 月 9 日](/jp/newsroom/2025/06/visionos-26-introduces-powerful-new-spatial-experiences-for-apple-vision-pro/)
+2025 年 6 月 9 日

--- a/tests/test_markdown_syntax.py
+++ b/tests/test_markdown_syntax.py
@@ -1,0 +1,14 @@
+import pathlib
+import re
+
+def test_media_syntax():
+    md_files = list(pathlib.Path('.').rglob('*.md'))
+    newline_pattern = re.compile(r'\[!\[\s*\n')
+    for path in md_files:
+        text = path.read_text(encoding='utf-8')
+        # check for newline after [![
+        assert not newline_pattern.search(text), f"multiline media syntax in {path}"
+        for idx, line in enumerate(text.splitlines(), 1):
+            if '[![' in line and line.strip().startswith('[!['):
+                if ')](' not in line:
+                    raise AssertionError(f"possible broken media syntax in {path}:{idx}")


### PR DESCRIPTION
## Summary
- fix malformed media links in Apple Intelligence article
- correct broken avatar links in Qiita clips
- add regression test for media syntax

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476e87ce60832ea128aecc995b1c1b