### PR TITLE
Add zenn.dev Claude Code tmux article clip

### DIFF
--- a/2025/06/zenn.dev/2025-06-10_beb87d102bd4f5.md
+++ b/2025/06/zenn.dev/2025-06-10_beb87d102bd4f5.md
@@ -1,0 +1,308 @@
+<!-- metadata -->
+- **title**: Claude Codeを並列組織化してClaude Code "Company"にするtmuxコマンド集
+- **source**: https://zenn.dev/kazuph/articles/beb87d102bd4f5
+- **author**: zenn.dev
+- **published**: 2025-06-09T00:00:00+09:00
+- **fetched**: 2025-06-10T02:10:53.579094+00:00
+- **tags**: codex
+- **image**: https://res.cloudinary.com/zenn/image/upload/s--AroizRzh--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:Claude%2520Code%25E3%2582%2592%25E4%25B8%25A6%25E5%2588%2597%25E7%25B5%2584%25E7%25B9%2594%25E5%258C%2596%25E3%2581%2597%25E3%2581%25A6Claude%2520Code%2520%2522Company%2522%25E3%2581%25AB%25E3%2581%2599%25E3%2582%258Btmux%25E3%2582%25B3%25E3%2583%259E%25E3%2583%25B3%25E3%2583%2589%25E9%259B%2586%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_37:kazuph%2Cx_203%2Cy_121/g_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyLzFjNmY3ODBlZDYuanBlZw==%2Cr_max%2Cw_90%2Cx_87%2Cy_95/v1627283836/default/og-base-w1200-v2.png
+
+## 要約
+
+tmuxの複数paneを用いてClaude Codeを並列実行し、各paneを部下と見立ててタスクを振り分け、報連相と/clearによる**トークン管理**を組み合わせることで効率的な**Claude Code Company**運営を実現する手順とベストプラクティスを解説し、大規模タスク分散などの活用例を示している。
+
+## 本文
+
+[![kazuph](https://storage.googleapis.com/zenn-user-upload/avatar/1c6f780ed6.jpeg)](/kazuph)
+
+🏢
+
+Claude Codeを並列組織化してClaude Code "Company"にするtmuxコマンド集
+====================================================
+
+2025/06/09に公開
+
+2025/06/10
+
+
+今日はこんなことをしてました。
+
+<https://x.com/kazuph/status/1931945076701475141>  
+<https://x.com/kazuph/status/1931945079440314506>
+
+最終的にタスクは完了したのですが、部長と部下で勝手に通信し合っておかしな話をしてました。
+
+<https://x.com/kazuph/status/1932019616089542808>
+
+今日はそんな感じにはっぴーはっぴーになったClaudeさんが、本日最後の仕事として書き上げた部下のマネジメントのためのtmuxコマンド集です。
+
+僕がそもそもバックエンドエンジニアでtmuxを使っていたので一部その辺を教え込んでますが、Claudeにtmuxでこれってどうやるの？とかtmux.confをいい感じにしてとか言うとやってくれるので、別にClaudeに聞けばわかることです。
+
+あなたがやるのは
+
+```
+tmux
+
+```
+
+を起動して
+
+```
+claude --dangerously-skip-permissions
+
+```
+
+としておくこと。もちろん `dangerously`オプションは自己責任でお願いします。
+
+そして、作るものを話し合って、それをタスク分解してあとは部下によろしくみたいなことを言うと起動したpaneに対して並列してタスクを投げて勝手に部下も報連相してくれます。
+
+僕のtmuxのwindowはこんな感じ。空にしてますが、サンプルプロジェクトを思いついたら動画を撮影するかもしれないです。
+
+![](https://storage.googleapis.com/zenn-user-upload/374b0f420a65-20250609.png)
+
+Ctrl-b + Spaceとすると色んな整頓された配置になるので試して下さい。
+
+あとそうそう、僕はMAX($100)プランです。従量課金している人は注意。
+
+![](https://storage.googleapis.com/zenn-user-upload/98ad68a1dbf2-20250609.png)
+
+ということで以下、Claude書いた記事。注意点は以下をあなたが実行するのではなくて、Claudeに教えておくことです。勝手に判断してやってくれます。
+
+tmuxを使った相互通信によるClaude Code Company管理方法
+======================================
+
+概要
+--
+
+tmuxの複数paneでClaude Codeインスタンスを並列実行し、効率的にタスクを分散処理する方法。
+
+基本セットアップ
+--------
+
+### 1. tmux pane構成作成
+
+```
+# 5つのpaneに分割
+tmux split-window -h && tmux split-window -v && tmux select-pane -t 0 && tmux split-window -v && tmux select-pane -t 2 && tmux split-window -v && tmux select-pane -t 4 && tmux split-window -v
+
+```
+
+### 2. pane番号の確認
+
+```
+# pane構造とIDの確認（実際の番号は環境により異なる）
+tmux list-panes -F "#{pane_index}: #{pane_id} #{pane_current_command} #{pane_active}"
+# 例の出力:
+# 0: %22 zsh 1  (メインpane)
+# 1: %27 zsh 0  (部下1)
+# 2: %28 zsh 0  (部下2)
+# 3: %25 zsh 0  (部下3) 
+# 4: %29 zsh 0  (部下4)
+# 5: %26 zsh 0  (部下5)
+
+```
+
+### 3. Claude Codeセッション起動
+
+**注意**: `cc`はClaude Codeのエイリアスです。事前に`alias cc="claude"`を設定するか、直接`claude`コマンドを使用してください。
+
+**%27等の番号について**: これらはtmuxが自動割り当てするpane IDです。上記の確認コマンドで実際のIDを確認してから使用してください。
+
+```
+# 全paneで並列起動（実際のpane IDに置き換えて使用）
+tmux send-keys -t %27 "cc" && sleep 0.1 && tmux send-keys -t %27 Enter & \
+tmux send-keys -t %28 "cc" && sleep 0.1 && tmux send-keys -t %28 Enter & \
+tmux send-keys -t %25 "cc" && sleep 0.1 && tmux send-keys -t %25 Enter & \
+tmux send-keys -t %29 "cc" && sleep 0.1 && tmux send-keys -t %29 Enter & \
+tmux send-keys -t %26 "cc" && sleep 0.1 && tmux send-keys -t %26 Enter & \
+wait
+
+```
+
+タスク割り当て方法
+---------
+
+### 基本テンプレート
+
+```
+tmux send-keys -t %27 "cd 'ワーキングディレクトリ' && あなたはpane1です。タスク内容。エラー時は[pane1]でtmux send-keys -t %22でメイン報告。" && sleep 0.1 && tmux send-keys -t %27 Enter
+
+```
+
+### 並列タスク割り当て例
+
+```
+tmux send-keys -t %27 "タスク1の内容" && sleep 0.1 && tmux send-keys -t %27 Enter & \
+tmux send-keys -t %28 "タスク2の内容" && sleep 0.1 && tmux send-keys -t %28 Enter & \
+tmux send-keys -t %25 "タスク3の内容" && sleep 0.1 && tmux send-keys -t %25 Enter & \
+wait
+
+```
+
+報連相システム
+-------
+
+### 部下からメインへの報告形式
+
+部下は以下のワンライナーで報告：
+
+```
+tmux send-keys -t %22 '[pane番号] 報告内容' && sleep 0.1 && tmux send-keys -t %22 Enter
+
+```
+
+部下から報連相できるように、タスク依頼時に上記の方法を教えて上げてください。また、`/clear` を頻繁にするので、2回目以降でもタスクの末尾に報連相の方法を加えておくと良いです。
+
+### 例
+
+```
+tmux send-keys -t %22 '[pane1] タスク完了しました' && sleep 0.1 && tmux send-keys -t %22 Enter
+tmux send-keys -t %22 '[pane3] エラーが発生しました：詳細内容' && sleep 0.1 && tmux send-keys -t %22 Enter
+
+```
+
+トークン管理
+------
+
+### /clearコマンドの実行
+
+部下は自分で/clearできないため、メインが判断して実行：
+
+**実行タイミングの判断基準**:
+
+* タスク完了時（新しいタスクに集中させるため）
+* トークン使用量が高くなった時（ccusageで確認）
+* エラーが頻発している時（コンテキストをリセット）
+* 複雑な作業から単純な作業に切り替える時
+
+```
+# 個別にクリア実行
+tmux send-keys -t %27 "/clear" && sleep 0.1 && tmux send-keys -t %27 Enter
+
+```
+
+### 並列/clear
+
+```
+tmux send-keys -t %27 "/clear" && sleep 0.1 && tmux send-keys -t %27 Enter & \
+tmux send-keys -t %28 "/clear" && sleep 0.1 && tmux send-keys -t %28 Enter & \
+tmux send-keys -t %25 "/clear" && sleep 0.1 && tmux send-keys -t %25 Enter & \
+wait
+
+```
+
+状況確認コマンド
+--------
+
+**なぜ必要か**: 部下からの報告に加えて、以下の場面でコマンド確認が有効です：
+
+* 部下が応答しない時（フリーズ、エラー状態の確認）
+* 報告内容の詳細確認（エラーメッセージの全文確認）
+* 作業状況の客観的把握（進捗の可視化）
+* トラブルシューティング時（ログの確認）
+
+### pane状況確認
+
+```
+# 各paneの最新状況確認
+tmux capture-pane -t %27 -p | tail -10
+tmux capture-pane -t %28 -p | tail -10
+
+```
+
+### 全pane一括確認
+
+```
+for pane in %27 %28 %25 %29 %26; do
+    echo "=== $pane ==="
+    tmux capture-pane -t $pane -p | tail -5
+done
+
+```
+
+ベストプラクティス
+---------
+
+### 1. 明確な役割分担
+
+* pane番号を必ず伝える
+* 担当タスクを具体的に指示
+* エラー時の報告方法を明記
+
+### 2. 効率的なコミュニケーション
+
+* ワンライナー形式での報告徹底
+* [pane番号]プレフィックス必須
+* 具体的なエラー内容の報告
+
+### 3. トークン使用量管理
+
+* 定期的な/clear実行
+* 大量トークン消費の監視
+* ccusageでの使用量確認
+
+### 4. エラー対処
+
+* Web検索による解決策調査を指示
+* 具体的エラー内容の共有
+* 成功事例の横展開
+
+注意事項
+----
+
+* 部下は直接/clearできない（tmux経由でのみ可能）
+* 報告は必ずワンライナー形式で
+* pane番号の確認を怠らない
+* トークン使用量の定期確認
+* 複雑な指示は段階的に分割
+
+活用例
+---
+
+### 大規模タスクの分散処理
+
+1. **資料作成**: 各paneで異なる章を担当
+2. **エラー解決**: 各paneで異なる角度から調査
+3. **知見共有**: 成功事例の文書化と横展開
+4. **品質管理**: 並列でのファイル修正と確認
+
+このシステムにより、複数のClaude Codeインスタンスを効率的に管理し、大規模タスクの並列処理が可能になります。
+
+[![kazuph](https://storage.googleapis.com/zenn-user-upload/avatar/1c6f780ed6.jpeg)](/kazuph)
+
+[kazuph](/kazuph)
+
+IoTエンジニア？最近はAIと共存する方法を探してます。
+
+バッジを贈って著者を応援しよう
+
+バッジを受け取った著者にはZennから現金やAmazonギフトカードが還元されます。
+
+バッジを贈る
+
+### Discussion
+
+![](https://static.zenn.studio/images/drawing/discussion.png)
+
+[![kazuph](https://storage.googleapis.com/zenn-user-upload/avatar/1c6f780ed6.jpeg)](/kazuph)
+
+[kazuph](/kazuph)
+
+IoTエンジニア？最近はAIと共存する方法を探してます。
+
+バッジを贈る
+
+[バッジを贈るとは](/faq#badges)
+
+目次
+
+1. [tmuxを使った相互通信によるClaude Code Company管理方法](#tmux%E3%82%92%E4%BD%BF%E3%81%A3%E3%81%9F%E7%9B%B8%E4%BA%92%E9%80%9A%E4%BF%A1%E3%81%AB%E3%82%88%E3%82%8Bclaude-code-company%E7%AE%A1%E7%90%86%E6%96%B9%E6%B3%95)
+   1. [概要](#%E6%A6%82%E8%A6%81)
+   2. [基本セットアップ](#%E5%9F%BA%E6%9C%AC%E3%82%BB%E3%83%83%E3%83%88%E3%82%A2%E3%83%83%E3%83%97)
+   3. [タスク割り当て方法](#%E3%82%BF%E3%82%B9%E3%82%AF%E5%89%B2%E3%82%8A%E5%BD%93%E3%81%A6%E6%96%B9%E6%B3%95)
+   4. [報連相システム](#%E5%A0%B1%E9%80%A3%E7%9B%B8%E3%82%B7%E3%82%B9%E3%83%86%E3%83%A0)
+   5. [トークン管理](#%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E7%AE%A1%E7%90%86)
+   6. [状況確認コマンド](#%E7%8A%B6%E6%B3%81%E7%A2%BA%E8%AA%8D%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89)
+   7. [ベストプラクティス](#%E3%83%99%E3%82%B9%E3%83%88%E3%83%97%E3%83%A9%E3%82%AF%E3%83%86%E3%82%A3%E3%82%B9)
+   8. [注意事項](#%E6%B3%A8%E6%84%8F%E4%BA%8B%E9%A0%85)
+   9. [活用例](#%E6%B4%BB%E7%94%A8%E4%BE%8B)


### PR DESCRIPTION
## Summary
- scrape zenn.dev article about managing Claude Code with tmux
- store metadata and Japanese summary
- include article content converted to Markdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684793ff9028832ea7dd1e5667fed01d