### PR TITLE
Fix video link test failures

### DIFF
--- a/2025/06/github.blog/2025-06-03_hack-the-model-build-ai-security-skills-with-the-github-secure-code-game.md
+++ b/2025/06/github.blog/2025-06-03_hack-the-model-build-ai-security-skills-with-the-github-secure-code-game.md
@@ -44,7 +44,7 @@ Each of the six security challenges focuses on a different defensive technique. 
 
 Progressing through season three requires players to hack LLMs. Each challenge begins with a set of guiding instructions for the LLM provided in the form of a code and a system message. These elements might include gaps or edge cases that could be exploited using a malicious prompt. Your task is to identify the vulnerabilities and craft prompts to manipulate the model into exposing a hidden secret.
 
-[![](https://github.blog/wp-content/uploads/2025/06/Screenshot-2025-06-02-at-11.52.51 AM.png)](https://github.blog/wp-content/uploads/2025/06/s3-demo.mp4)
+![video](https://github.blog/wp-content/uploads/2025/06/s3-demo.mp4)
 
 After exploiting the vulnerability, your next task is to refine the code and system message to prevent future leaks from those malicious prompts. You must do this while maintaining the functionality of the code.
 

--- a/2025/06/github.blog/2025-06-06_assigning-and-completing-issues-with-coding-agent-in-github-copilot.md
+++ b/2025/06/github.blog/2025-06-06_assigning-and-completing-issues-with-coding-agent-in-github-copilot.md
@@ -18,7 +18,7 @@ This isn’t just autocomplete. It’s a new class of software engineering agent
 
 Oh, and if you’re a visual learner we have you covered. 👇
 
-[![](https://github.blog/wp-content/uploads/2025/06/Screenshot-2025-06-05-at-11.22.28 AM.png)](https://github.blog/wp-content/uploads/2025/06/Copilot-Coding-Agent-Overview-v3-Burned.mp4)
+![video](https://github.blog/wp-content/uploads/2025/06/Copilot-Coding-Agent-Overview-v3-Burned.mp4)
 
 ## Coding agent in GitHub Copilot 101
 

--- a/2025/06/www.apple.com/2025-06-09_apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices.md
+++ b/2025/06/www.apple.com/2025-06-09_apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices.md
@@ -64,7 +64,7 @@ Apple Intelligenceの機能は年末までに、デンマーク語、オラン�
 
 ジェン文字とImage Playgroundは、ユーザーにさらに多くの自己表現の方法を提供します。テキストによる説明をジェン文字に変換するだけでなく、絵文字を取り入れ、それらを説明と組み合わせることによって、新しいものを作り出せるようになります。ジェン文字やImage Playgroundを使用して、家族や友人からインスピレーションを得た画像を作成する際、ユーザーは表現方法を変更したり、例えば友人の最新の見た目に合わせてヘアスタイルを変えるなど、個人の特徴を調整したりできます。
 
-[![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-genmoji-mix/posters/Apple-WWDC25-Apple-Intelligence-Genmoji-mix-250609.jpg.large_2x.jpg)](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-genmoji-mix/large_2x.mp4)
+![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-genmoji-mix/large_2x.mp4)
 
 ジェン文字の機能強化により、ユーザーは絵文字を取り入れ、説明と組み合わせることによって新しいものを作り出すオプションを活用し、より多くの方法で自己表現できるようになります。
 
@@ -79,19 +79,19 @@ Image Playgroundでは、ChatGPTによって油絵風やベクターアートな
 
 Apple Intelligenceを基盤とするビジュアルインテリジェンスがユーザーのiPhoneの画面に拡張され、ユーザーはあらゆるアプリで、画面上に表示しているものを検索し操作できます。
 
-[![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-etsy/posters/Apple-WWDC25-Apple-Intelligence-Visual-Intelligence-with-Etsy-250609.jpg.large_2x.jpg)](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-etsy/large_2x.mp4)
+![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-etsy/large_2x.mp4)
 
 Apple Intelligenceのアップデートで、ビジュアルインテリジェンスがユーザーのiPhoneの画面上に表示されているコンテンツに拡張され、GoogleやEtsyなどの対応アプリを使って似たようなものを探すといった操作が可能になります。
 
 ビジュアルインテリジェンスはすでに、ユーザーがiPhoneのカメラを使用して周囲の対象物や場所について学ぶのに役立っていますが、これからはiPhoneの画面上に表示されているものについて、より多くのことを、より速く実行できるようになります。ユーザーは画面上で見ているものについてChatGPTに質問して詳しい情報を得たり、GoogleやEtsyなどの対応アプリで検索して類似の画像や製品を見つけたりできます。例えばランプなど、特に興味を惹かれるものが表示されている場合、ユーザーはそれをハイライトし、同じものや似たようなものをオンラインで検索することができます。
 
-[![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-chatgpt/posters/Apple-WWDC25-Apple-Intelligence-Visual-Intelligence-with-ChatGPT-250609.jpg.large_2x.jpg)](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-chatgpt/large_2x.mp4)
+![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-with-chatgpt/large_2x.mp4)
 
 ビジュアルインテリジェンスによって、ユーザーは特定の対象物についての詳細をChatGPTに質問することができます。
 
 ビジュアルインテリジェンスは、イベントが表示されていることを認識してカレンダーへの追加を提案し4、Apple Intelligenceが関連するデータを抽出してイベントを作成します。
 
-[![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-add-to-calendar/posters/Apple-WWDC25-Apple-Intelligence-Visual-Intelligence-add-to-Calendar-250609.jpg.large_2x.jpg)](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-add-to-calendar/large_2x.mp4)
+![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-visual-intelligence-add-to-calendar/large_2x.mp4)
 
 ビジュアルインテリジェンスは、イベントが表示されていることを認識してカレンダーへの追加を提案し、Apple Intelligenceが関連するデータを抽出してイベントを作成します。
 
@@ -106,7 +106,7 @@ Workout Buddyは、Apple Intelligenceを利用した、ほかに類を見ないA
 
 Workout Buddyは、Bluetoothヘッドフォンを接続したApple Watchで利用でき、Apple Intelligence対応のiPhoneが近くにあることが必要です。屋外および屋内のランニング、屋外および屋内のウォーキング、屋外のサイクリング、高強度インターバルトレーニング、機能的および従来型筋力トレーニングなど、人気の高いワークアウトの種類の一部において、まずは英語で利用できるようになります。
 
-[![動画](https://www.apple.com/newsroom/videos/2025/hls/06/watchOS-26/Web/US/posters/Apple-WWDC25-watchOS-26-Apple-Intelligence-Workout-Buddy-250609_571x321.jpg.large.jpg)](https://www.apple.com/newsroom/videos/2025/hls/06/watchOS-26/Web/US/apple-wwdc25-watchos-26-apple-intelligence-workout-buddy-250609_16x9.m3u8)
+![動画](https://www.apple.com/newsroom/videos/2025/hls/06/watchOS-26/Web/US/apple-wwdc25-watchos-26-apple-intelligence-workout-buddy-250609_16x9.m3u8)
 
 Apple Watchに登場するWorkout Buddyは、Apple Intelligenceを利用した、ほかに類を見ないワークアウト体験で、ユーザーのワークアウトのデータと個人的なフィットネス履歴を取り込み、パーソナライズされた洞察を生成してモチベーションを高めます。
 
@@ -115,13 +115,13 @@ Apple Watchに登場するWorkout Buddyは、Apple Intelligenceを利用した�
 
 Appleは、Apple Intelligenceの中核にあるデバイス上の基盤モデルをどのアプリからでも直接利用できるようにしました。
 
-[![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-kahoot/posters/Apple-WWDC25-Apple-Intelligence-on-device-Foundation-Model-framework-Kahoot-250609.jpg.large_2x.jpg)](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-kahoot/large_2x.mp4)
+![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-kahoot/large_2x.mp4)
 
 基盤モデルフレームワークにより、デベロッパはApple Intelligenceの中核にあるデバイス上の基盤モデルを直接利用できるようになり、パワフルかつ高速で、プライバシーが組み込まれ、ユーザーがオフラインの時にも使えるインテリジェンスにアクセスできます。
 
 基盤モデルフレームワークを利用すれば、アプリのデベロッパはApple Intelligenceをベースに、無料のAI推論を利用して、インテリジェントで、オフラインでも利用でき、プライバシーが保護される新たな体験をユーザーに提供できるようになります。例えば教育アプリなら、デバイス上のモデルを利用して、クラウドAPIの費用をかけることなく、ユーザーのメモをもとにパーソナライズされたクイズを作成でき、アウトドアアプリなら、ユーザーがオフラインの時にも使える自然な言葉づかいでの検索機能を追加できます。
 
-[![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-alltrails/posters/Apple-WWDC25-Apple-Intelligence-on-device-Foundation-Model-framework_AllTrails-250609.jpg.large_2x.jpg)](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-alltrails/large_2x.mp4)
+![動画](https://www.apple.com/newsroom/videos/2025/autoplay/06/apple-intelligence-gets-even-more-powerful-with-new-capabilities-across-apple-devices/apple-wwdc25-apple-intelligence-on-device-foundation-model-framework-alltrails/large_2x.mp4)
 
 基盤モデルフレームワークはSwiftにネイティブ対応しているため、アプリのデベロッパはたった3行のコードでApple Intelligenceのモデルを簡単に利用できます。
 

--- a/2025/06/www.cursor.com/2025-06-04_changelog-cursor-the-ai-code-editor.md
+++ b/2025/06/www.cursor.com/2025-06-04_changelog-cursor-the-ai-code-editor.md
@@ -23,7 +23,7 @@ When an issue is found, BugBot leaves a comment on your PRs in GitHub. You can c
 
 To set it up, follow instructions in our [BugBot docs](https://docs.cursor.com/bugbot)
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/1-0/bug-bot-web.mp4)
+![video](https://www.cursor.com/changelog/1-0/bug-bot-web.mp4)
 
 ### Background Agent for everyone
 
@@ -37,7 +37,7 @@ Cursor can now implement changes in Jupyter Notebooks!
 
 Agent will now create and edit multiple cells directly inside of Jupyter, a significant improvement for research and data science tasks. Only supported with Sonnet models to start.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/1-0/jupyter-notebooks-web.mp4)
+![video](https://www.cursor.com/changelog/1-0/jupyter-notebooks-web.mp4)
 
 ### Memories
 
@@ -45,7 +45,7 @@ With Memories, Cursor can remember facts from conversations and reference them i
 
 We're rolling out Memories as a beta feature. To get started, enable from Settings → Rules.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/1-0/memories-web.mp4)
+![video](https://www.cursor.com/changelog/1-0/memories-web.mp4)
 
 ### MCP one-click install and OAuth support
 
@@ -55,15 +55,15 @@ We've curated a short list of official MCP servers you can add to Cursor at [doc
 
 If you're an MCP developer, you can easily make your server available to developers by adding a *Add to Cursor* button in your documentation and READMEs. Generate one at [docs.cursor.com/deeplinks](https://docs.cursor.com/deeplinks)
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/1-0/mcp-one-click.mp4)
+![video](https://www.cursor.com/changelog/1-0/mcp-one-click.mp4)
 
 ### Richer Chat responses
 
 Cursor can now render visualizations inside of a conversation. In particular, Mermaid diagrams and Markdown tables can now be generated and viewed in the same place!
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/1-0/mermaid-web.mp4)
+![video](https://www.cursor.com/changelog/1-0/mermaid-web.mp4)
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/1-0/markdown-web.mp4)
+![video](https://www.cursor.com/changelog/1-0/markdown-web.mp4)
 
 ### New Settings and Dashboard
 
@@ -112,7 +112,7 @@ The pricing is straightforward: you're charged based on token usage. If you've u
 
 Read more about Max Mode in our [documentation](https://docs.cursor.com/context/max-mode)
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/050/max-mode.mp4)
+![video](https://www.cursor.com/changelog/050/max-mode.mp4)
 
 ### New Tab model
 
@@ -128,13 +128,13 @@ This allows you to run many agents in parallel and have them tackle bigger tasks
 
 We're curious to hear what you think. While it is still early, we've found background agents useful internally for fixing nits, doing investigations, and writing first drafts of medium-sized PRs. Read more at [docs.cursor.com/background-agent](https://docs.cursor.com/background-agent).
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/050/bg.mp4)
+![video](https://www.cursor.com/changelog/050/bg.mp4)
 
 ### Include your entire codebase in context
 
 You can now use `@folders` to add your entire codebase into context, just make sure to enable `Full folder contents` from settings. If a folder (or file) is too large to be included, you'll see a small icon on the context pill indicating this.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/050/root.mp4)
+![video](https://www.cursor.com/changelog/050/root.mp4)
 
 ### Refreshed Inline Edit (Cmd/Ctrl+K) with Agent integration
 
@@ -142,13 +142,13 @@ Inline Edit (Cmd/Ctrl+K) has gotten a UI refresh and new options for full file e
 
 Full file makes it easy to do scope changes to a file without using agent. However, you might come across cases where you're working with a piece of code you want to make multi-file edits to or simply just want more control you can get from agent. That's when you want to send selected codeblock to agent and keep on editing from there.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/050/cmdk.mp4)
+![video](https://www.cursor.com/changelog/050/cmdk.mp4)
 
 ### Fast edits for long files with Agent
 
 We've added a new tool to the agent that will search & replace code in files, making it much more efficient for long files. Instead of reading the complete file, Agent can now find the exact place where edits should occur and change only that part. Here's an example editing a file in [Postgres codebase](https://github.com/postgres/postgres/blob/master/src/backend/tcop/postgres.c) where using search & replace tool is nearly double as fast. We're rolling this out to Anthropic models first and will expand to other models soon.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/050/search-n-replace.mov)
+![video](https://www.cursor.com/changelog/050/search-n-replace.mov)
 
 ### Work in multiple codebases with workspaces
 
@@ -162,13 +162,13 @@ Now you can create multi-root workspaces to make multiple codebases available to
 
 You can now export chats to markdown from the chat view. Text and code blocks are included in the final export.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/050/export-chat.mp4)
+![video](https://www.cursor.com/changelog/050/export-chat.mp4)
 
 #### Duplicate Chats
 
 Exploring different paths from a conversation while preserving the existing is now possible with chat duplication. Go to a message and start a new chat from the three dots menu.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/050/duplicate-chat.mp4)
+![video](https://www.cursor.com/changelog/050/duplicate-chat.mp4)
 
 Keybindings (1)
 
@@ -240,7 +240,7 @@ For `Auto Attached` rules with path patterns defined, Agent will now automatical
 
 We’ve also fixed a long-standing issue where `Always` attached rules now persist across longer conversations. Agent can now also edit rules reliably.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/049/generate-rules.mp4)
+![video](https://www.cursor.com/changelog/049/generate-rules.mp4)
 
 ### More accessible history
 
@@ -250,19 +250,19 @@ Chat history has moved into the command palette. You can access it from the "Sho
 
 Reviewing agent generated code is now easier with a built-in diff view at the end of each conversation. You'll find the `Review changes` button at the bottom of chat after a message from the agent.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/049/review-ui.mp4)
+![video](https://www.cursor.com/changelog/049/review-ui.mp4)
 
 ### Images in MCP
 
 You can now pass images as part of the context in MCP servers. This helps when screenshots, UI mocks, or diagrams add essential context to a question or prompt.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/049/mcp-image.mp4)
+![video](https://www.cursor.com/changelog/049/mcp-image.mp4)
 
 ### Improved agent terminal control
 
 We've added more control for you over terminals started by the agent. Commands can now be edited before they run, or skipped entirely. We've also renamed "Pop-out" to "Move to background" to better reflect what it does.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/049/agent-terminal.mp4)
+![video](https://www.cursor.com/changelog/049/agent-terminal.mp4)
 
 ### Global ignore files
 
@@ -384,7 +384,7 @@ Create new tabs (⌘T) in chat to have multiple conversations in parallel. You c
 
 When a tab is awaiting your input, you'll see an orange dot on that tab.
 
-[Your browser does not support the video tag.](https://www.cursor.com/changelog/048/chat-tabs.mp4)
+![video](https://www.cursor.com/changelog/048/chat-tabs.mp4)
 
 ### Faster indexing
 


### PR DESCRIPTION
## Summary
- fix markdown video link format in GitHub Copilot article
- fix markdown video link format in security game article
- update Cursor changelog with proper video links
- update Apple Intelligence article with proper video links

## Testing
- `pytest -q tests/test_video_links.py`

------
https://chatgpt.com/codex/tasks/task_e_6847bd459c54832e807bf23a73121636