### PR TITLE
Add Prettier runner for summary directories

### DIFF
--- a/node_tools/run_prettier.js
+++ b/node_tools/run_prettier.js
@@ -1,0 +1,23 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const root = process.cwd();
+
+// Collect year directories like 2025, 2023
+const yearDirs = fs
+  .readdirSync(root)
+  .filter((name) => /^\d{4}$/.test(name))
+  .filter((name) => fs.statSync(path.join(root, name)).isDirectory());
+
+if (yearDirs.length === 0) {
+  console.error("No year directories found.");
+  process.exit(1);
+}
+
+// Build globs for Prettier
+const globs = yearDirs.map((dir) => `"${dir}/**/*"`).join(" ");
+
+const cmd = `npx prettier --write ${globs}`;
+console.log(cmd);
+execSync(cmd, { stdio: "inherit", shell: true });


### PR DESCRIPTION
## Summary
- create `node_tools/run_prettier.js` to format every file under year folders (e.g. `2025`, `2023`)

## Testing
- `npx prettier --write node_tools/run_prettier.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684823aa2d50832e9e60f5af9c3843ae