### PR TITLE
Add new clip for gemini-fullstack-langgraph-quickstart

### DIFF
--- a/2025/06/github.com/2025-06-11_gemini-fullstack-langgraph-quickstart.md
+++ b/2025/06/github.com/2025-06-11_gemini-fullstack-langgraph-quickstart.md
@@ -1,0 +1,127 @@
+<!-- metadata -->
+
+- **title**: GitHub - google-gemini/gemini-fullstack-langgraph-quickstart: Get started with building Fullstack Agents using Gemini 2.5 and LangGraph
+- **source**: https://github.com/google-gemini/gemini-fullstack-langgraph-quickstart
+- **author**: google-gemini
+- **published**:
+- **fetched**: 2025-06-11T09:36:59.987264+00:00
+- **tags**: codex, gemini, langgraph, react, fastapi, docker, tutorial, open-source
+- **image**: https://opengraph.githubassets.com/89cb8f8bfd8a67e483f61af309a20788808acc37cbf2c8a185d44cc68b167393/google-gemini/gemini-fullstack-langgraph-quickstart
+
+## 要約
+
+Gemini 2.5とLangGraphを活用し、検索用のクエリ生成からWebリサーチ、足りない情報の検出、再検索、最終回答生成までを自動で行う**フルスタックエージェント**の実装例。React + Vite製のフロントエンドとFastAPIバックエンドを連携し、リアルタイム表示用にRedis、永続化にPostgresを使用する。開発モードではホットリロード、本番環境用にはDockerとdocker-composeによるデプロイ手順まで解説しており、実践的なLLMエージェント開発を一気通貫で体験できる。特徴として、エージェントの処理フローを図示し、Geminiモデルが検索クエリ生成と反省フェーズ、回答生成を担う様子を説明している。Google Search APIを使ったウェブ情報取得や、LangGraphのスレッド管理機能によるステップ実行も記載。
+
+## 本文
+
+# Gemini Fullstack LangGraph Quickstart
+
+This project demonstrates a fullstack application using a React frontend and a LangGraph-powered backend agent. The agent is designed to perform comprehensive research on a user's query by dynamically generating search terms, querying the web using Google Search, reflecting on the results to identify knowledge gaps, and iteratively refining its search until it can provide a well-supported answer with citations. This application serves as an example of building research-augmented conversational AI using LangGraph and Google's Gemini models.
+
+![Gemini Fullstack LangGraph](https://raw.githubusercontent.com/google-gemini/gemini-fullstack-langgraph-quickstart/main/app.png)
+
+## Features
+
+- 💬 Fullstack application with a React frontend and LangGraph backend.
+- 🧠 Powered by a LangGraph agent for advanced research and conversational AI.
+- 🔍 Dynamic search query generation using Google Gemini models.
+- 🌐 Integrated web research via Google Search API.
+- 🤔 Reflective reasoning to identify knowledge gaps and refine searches.
+- 📄 Generates answers with citations from gathered sources.
+- 🔄 Hot-reloading for both frontend and backend development during development.
+
+## Project Structure
+
+The project is divided into two main directories:
+
+- `frontend/`: Contains the React application built with Vite.
+- `backend/`: Contains the LangGraph/FastAPI application, including the research agent logic.
+
+## Getting Started: Development and Local Testing
+
+Follow these steps to get the application running locally for development and testing.
+
+**1. Prerequisites:**
+
+- Node.js and npm (or yarn/pnpm)
+- Python 3.8+
+- **`GEMINI_API_KEY`**: The backend agent requires a Google Gemini API key.
+  1.  Navigate to the `backend/` directory.
+  2.  Create a file named `.env` by copying the `backend/.env.example` file.
+  3.  Open the `.env` file and add your Gemini API key: `GEMINI_API_KEY="YOUR_ACTUAL_API_KEY"`
+
+**2. Install Dependencies:**
+
+**Backend:**
+
+```bash
+cd backend
+pip install .
+```
+
+**Frontend:**
+
+```bash
+cd frontend
+npm install
+```
+
+**3. Run Development Servers:**
+
+**Backend & Frontend:**
+
+```bash
+make dev
+```
+
+This will run the backend and frontend development servers. Open your browser and navigate to the frontend development server URL (e.g., `http://localhost:5173/app`).
+
+_Alternatively, you can run the backend and frontend development servers separately. For the backend, open a terminal in the `backend/` directory and run `langgraph dev`. The backend API will be available at `http://127.0.0.1:2024`. It will also open a browser window to the LangGraph UI. For the frontend, open a terminal in the `frontend/` directory and run `npm run dev`. The frontend will be available at `http://localhost:5173`._
+
+## How the Backend Agent Works (High-Level)
+
+The core of the backend is a LangGraph agent defined in `backend/src/agent/graph.py`. It follows these steps:
+
+![Agent Flow](https://raw.githubusercontent.com/google-gemini/gemini-fullstack-langgraph-quickstart/main/agent.png)
+
+1.  **Generate Initial Queries:** Based on your input, it generates a set of initial search queries using a Gemini model.
+2.  **Web Research:** For each query, it uses the Gemini model with the Google Search API to find relevant web pages.
+3.  **Reflection & Knowledge Gap Analysis:** The agent analyzes the search results to determine if the information is sufficient or if there are knowledge gaps. It uses a Gemini model for this reflection process.
+4.  **Iterative Refinement:** If gaps are found or the information is insufficient, it generates follow-up queries and repeats the web research and reflection steps (up to a configured maximum number of loops).
+5.  **Finalize Answer:** Once the research is deemed sufficient, the agent synthesizes the gathered information into a coherent answer, including citations from the web sources, using a Gemini model.
+
+## Deployment
+
+In production, the backend server serves the optimized static frontend build. LangGraph requires a Redis instance and a Postgres database. Redis is used as a pub-sub broker to enable streaming real time output from background runs. Postgres is used to store assistants, threads, runs, persist thread state and long term memory, and to manage the state of the background task queue with 'exactly once' semantics. For more details on how to deploy the backend server, take a look at the [LangGraph Documentation](https://langchain-ai.github.io/langgraph/concepts/deployment_options/). Below is an example of how to build a Docker image that includes the optimized frontend build and the backend server and run it via `docker-compose`.
+
+_Note: For the docker-compose.yml example you need a LangSmith API key, you can get one from [LangSmith](https://smith.langchain.com/settings)._
+
+_Note: If you are not running the docker-compose.yml example or exposing the backend server to the public internet, you update the `apiUrl` in the `frontend/src/App.tsx` file your host. Currently the `apiUrl` is set to `http://localhost:8123` for docker-compose or `http://localhost:2024` for development._
+
+**1. Build the Docker Image:**
+
+Run the following command from the **project root directory**:
+
+```bash
+docker build -t gemini-fullstack-langgraph -f Dockerfile .
+```
+
+**2. Run the Production Server:**
+
+```bash
+GEMINI_API_KEY=<your_gemini_api_key> LANGSMITH_API_KEY=<your_langsmith_api_key> docker-compose up
+```
+
+Open your browser and navigate to `http://localhost:8123/app/` to see the application. The API will be available at `http://localhost:8123`.
+
+## Technologies Used
+
+- [React](https://reactjs.org/) (with [Vite](https://vitejs.dev/)) - For the frontend user interface.
+- [Tailwind CSS](https://tailwindcss.com/) - For styling.
+- [Shadcn UI](https://ui.shadcn.com/) - For components.
+- [LangGraph](https://github.com/langchain-ai/langgraph) - For building the backend research agent.
+- [Google Gemini](https://ai.google.dev/models/gemini) - LLM for query generation, reflection, and answer synthesis.
+
+## License
+
+This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- scrape google-gemini/gemini-fullstack-langgraph-quickstart README
- add metadata, tags, and Japanese summary
- include images using raw GitHub URLs

## Testing
- `node node_tools/run_prettier.js`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68494de11c30832e948f669abba61b4e