### PR TITLE
Add pre-commit hook for pytest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: local
+  hooks:
+  - id: pytest
+    name: pytest
+    entry: pytest -q
+    language: system
+    pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
    ```bash
    pip install uv
    uv pip install -r requirements.txt
+   pre-commit install
    ```
 
 ---
@@ -117,7 +118,9 @@ repo-root
 
 ## 6. テスト
 
-要約を作成してコミットする前に `pytest -q` を実行し、エラーがないことを確認してください。すべて完了したら PR を作成します。
+`pre-commit` を導入しています。初回のみ `pre-commit install` を実行してください。
+コミット時に自動で `pytest -q` が実行されます。手動で確認したい場合は
+`pre-commit run --all-files` を使ってください。すべて完了したら PR を作成します。
 
 ⸻
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ PyPDF2
 readability-lxml
 requests
 pytest
+pre-commit


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` to run `pytest -q`
- install `pre-commit` via requirements
- document the hook usage in README

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684dfd1b3e04832ea4e2614b84013153