### PR TITLE
Fix summary placeholder text

### DIFF
--- a/python_tools/fetch_paper.py
+++ b/python_tools/fetch_paper.py
@@ -17,6 +17,8 @@ import requests
 from PyPDF2 import PdfReader
 import json
 
+SUMMARY_PLACEHOLDER = "<ここに日本語の要約を書く>"
+
 
 def clean_text(raw_text: str) -> str:
     """Remove spurious line breaks and hyphenation."""
@@ -169,7 +171,8 @@ def fetch_paper(doi: str, out_dir: Path) -> Optional[Path]:
         f.write("image: \n")
         f.write("---\n\n")
         f.write("## 要約\n\n")
-        f.write("TODO: summary\n\n")
+        summary_md = SUMMARY_PLACEHOLDER
+        f.write(summary_md + "\n\n")
         f.write("## 本文\n\n")
         f.write(txt_path.read_text(encoding="utf-8"))
 

--- a/python_tools/scrape.py
+++ b/python_tools/scrape.py
@@ -14,6 +14,8 @@ from markdownify import markdownify as md
 url = sys.argv[1]
 parsed_url = urlparse(url)
 
+SUMMARY_PLACEHOLDER = "<ここに日本語の要約を書く>"
+
 html = None
 def parse_rjina_text(text):
     lines = text.splitlines()
@@ -195,7 +197,8 @@ with open(filepath, "w") as f:
     f.write(f"image: {image}\n")
     f.write("---\n\n")
     f.write("## 要約\n\n")
-    f.write("TODO: summary\n\n")
+    summary_md = SUMMARY_PLACEHOLDER
+    f.write(summary_md + "\n\n")
     f.write("## 本文\n\n")
     f.write(content_md)
 


### PR DESCRIPTION
## Summary
- standardize summary placeholder
- create constant `SUMMARY_PLACEHOLDER` used in scraping tools

## Testing
- `pre-commit` *(fails: Username for 'https://github.com')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68501ddc5290832eb6c0b95c2d590f1d