### PR TITLE
Fix pre-commit filters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,21 +5,25 @@ repos:
         name: ruff lint
         entry: ruff --ignore=E501
         language: system
+        types: [python]
 
       - id: ruff-format
         name: ruff format
         entry: ruff format
         language: system
+        types: [python]
 
       - id: black
         name: black
         entry: black
         language: system
+        types: [python]
 
       - id: pyright
         name: pyright
         entry: pyright --pythonversion 3.12
         language: system
+        types: [python]
 
       - id: pytest
         name: pytest


### PR DESCRIPTION
## Summary
- restrict ruff, ruff-format, black and pyright hooks to Python files
- remove example summary markdown file

## Testing
- `pre-commit run --files .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6850270a37cc832ead13b580e66bdd3c