### PR TITLE
Add clip: zenn.dev article on unlocking version lock

### DIFF
--- a/Summary/2025/06/zenn.dev/2025-06-16_fdea210f6ed6e9.md
+++ b/Summary/2025/06/zenn.dev/2025-06-16_fdea210f6ed6e9.md
@@ -1,0 +1,192 @@
+---
+title: '[Tips] NGC PyTorchのversion lockを解除する方法'
+source: https://zenn.dev/turing_motors/articles/fdea210f6ed6e9
+author:
+  - zenn.dev
+published: ''
+fetched: '2025-06-16T15:37:14.445143+00:00'
+tags:
+  - codex
+  - pytorch
+  - docker
+image: https://res.cloudinary.com/zenn/image/upload/s--Y4R_wR_t--/c_fit%2Cg_north_west%2Cl_text:notosansjp-medium.otf_55:%255BTips%255D%2520NGC%2520PyTorch%25E3%2581%25AEversion%2520lock%25E3%2582%2592%25E8%25A7%25A3%25E9%2599%25A4%25E3%2581%2599%25E3%2582%258B%25E6%2596%25B9%25E6%25B3%2595%2Cw_1010%2Cx_90%2Cy_100/g_south_west%2Cl_text:notosansjp-medium.otf_34:Kazuki%2520Fujii%2Cx_220%2Cy_108/bo_3px_solid_rgb:d6e3ed%2Cg_south_west%2Ch_90%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyL2VhNmQ4MDk1OGQuanBlZw==%2Cr_20%2Cw_90%2Cx_92%2Cy_102/co_rgb:6e7b85%2Cg_south_west%2Cl_text:notosansjp-medium.otf_30:Tech%2520Blog%2520-%2520Turing%2Cx_220%2Cy_160/bo_4px_solid_white%2Cg_south_west%2Ch_50%2Cl_fetch:aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL3plbm4tdXNlci11cGxvYWQvYXZhdGFyL2NiYTAwZDNmYWIuanBlZw==%2Cr_max%2Cw_50%2Cx_139%2Cy_84/v1627283836/default/og-base-w1200-v2.png
+---
+
+## 要約
+NGC PyTorchコンテナはCUDAなど主要ライブラリが揃い便利だが、デフォルトの`/etc/pip/constraint.txt`でPythonパッケージの**version lock**が行われており、`pip install`で別バージョンを入れようとするとエラーになる。lock解除はconstraintファイルの該当行を書き換えるだけで、例として`black==25.1.0`を`25.2.0`に、`nvidia-modelopt`を`0.27.0`に更新後`pip install`を実行すると解決できる。最新イメージが常に最適とは限らないため動作確認をしつつ理解して使う必要がある。
+
+
+
+## 本文
+
+はじめに
+----
+
+[Turing](https://tur.ing/en)の基盤AIチームに業務委託として所属している東京科学大学(Institute of Science Tokyo)の藤井です。本記事では、NVIDIA NGC PyTorchのcontainerを利用する際に直面するversion lock問題に関する知見や注意点について紹介します。
+
+普段は[Swallow Project](https://swallow-llm.github.io/index.ja.html)や[横田研究室](https://www.rio.gsic.titech.ac.jp/jp/)にて大規模モデルの分散並列学習や低精度学習について研究を行っていますので、そちらもご覧いただけますと幸いです。
+
+NGC PyTorchとは
+-------------
+
+NGC PyTorchとは、NVIDIAが提供しているコンテナの総称であり、LLMの学習やNLP研究などに必要とされる主要なライブラリの依存関係をNVIDIAが確認し、installしてくれている便利なコンテナのことを指します。約1ヶ月ごとに定期的にversion up等の処理がなされているのも魅力的です。  
+コンテナの環境内には、CUDA Toolkit, nccl等もインストールされているため、特殊なライブラリを利用するわけではない場合は、すぐに実験や研究を開始できます。
+
+以下のリンクから使用方法等を確認できます。  
+<https://catalog.ngc.nvidia.com/orgs/nvidia/containers/pytorch>
+
+!
+
+常に最新のImageを利用するのが良いのでしょうか？
+
+そういう訳でもありません。  
+例えば、2025年6月現在の最新versionは25.05ですが、このversionにインストールされているPyTorch 2.8.0では、NeMo, Megatron-LMにおいてdistributed checkpoint saveの実装が追いついておらず、自前の変更を余儀なくされる等の問題があります。
+
+ローカルでの環境構築でも同様ですが、意味もなく最新versionを利用するということは控えるべきかと思います。(自前で解決できるのであれば、その限りではありませんが)
+
+!
+
+versionによっては正しく動作しないversionがあると思いますが...
+
+はい、そうですね。稀にそのようなversionもあります。  
+例えば、2025年6月時点で2番目に新しい25.04には、以下のようにしないと 正しく動作しない問題があります。
+
+```
+    mkdir -p /usr/local/cuda/compat/lib
+    cp -s /usr/local/cuda-12.9/compat/lib.real/* /usr/local/cuda/compat/lib/
+
+```
+
+このように、NGC PyTorchは使いやすいですが、ローカル環境構築で味わっていたすべての苦労から解放されるかというと、案外そうではない側面があります。  
+ブラックボックス化せずに、何事も理解して使うことが肝要であるということには変わりはないと思います。
+
+NGC PyTorch 直面する問題
+------------------
+
+多くの方がPre-Trained modelを利用して研究開発を行う際に利用するhuggingface transformersですが、あるversion以上でないと特定のモデルをサポートしていないことがあります。このように、研究開発で利用するライブラリのversionを上げたい or 下げたいという欲求はよくあると思います。
+
+しかし、NGC PyTorchにdefaultでインストールされているライブラリにはversion lockがかけられており、versionを自由に変更することができません。  
+以降では、このversion lockをどのように外すのかについて解説を行います。
+
+version lock
+------------
+
+NGC PyTorchは、PyTorchを利用したDeepLearningを行う上で必須のライブラリが大体インストールされている便利なコンテナなのですが、少々使いづらい点があります。  
+そのうちの1つは、上述したversion lockです。
+
+version lockとは、container内にdefaultでinstallされているらpython package versionを特定のversionに固定するものであり、以下のように`pip install`で異なるversionのライブラリをインストールしようとするとエラーが発生してしまいます。
+
+```
+ERROR: Cannot install nvidia-modelopt==0.27.0 because these package versions have conflicting dependencies.
+
+The conflict is caused by:
+    The user requested nvidia-modelopt==0.27.0
+    The user requested (constraint) nvidia-modelopt==0.25.0
+
+To fix this you could try to:
+1. loosen the range of package versions you've specified
+2. remove package versions to allow pip to attempt to solve the dependency conflict
+
+ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/
+
+```
+
+!
+
+なぜversion lockをしているのですか？
+
+公式ページに記載がありますが、意図しないpackageの依存関係の上書きを防ぐことが主な目的です。  
+NGC PyTorchには多くのPython packageがインストールされています。そのため、安易にpip installを行いますと、関係しないライブラリの依存関係も上書きしてしまう可能性があります。  
+また、NVIDIA側がテストを行っていないversionの組み合わせですと、もしかすると想定とは異なる挙動をするかもしれません。(apiの仕様変更、default valueの変更など)
+
+これらの問題を回避するために意図してversion lockが行われています。
+
+解除方法
+----
+
+version lcokの解除方法はいたってシンプルです。  
+コンテナ内に入ると`/etc/pip/constraint.txt`にinstall済みのpackage versionを固定するためのファイルが存在しています。こちらを`vim`等のコマンドで開き、versionとして指定されているものを変更するだけです。
+
+以下は一部分を抜粋したものですが、以下のようにpackageごとにversionが規定されています。
+
+```
+black==25.1.0
+expecttest==0.3.0
+cudf-polars==25.2.0
+isoduration==20.11.0
+referencing==0.36.2
+jsonschema-specifications==2024.10.1
+sortedcontainers==2.4.0
+spacy-legacy==3.0.12
+pybind11==2.13.6
+jedi==0.19.2
+
+```
+
+そのため、仮にblackのversionを変えたい場合は、以下のように変更すれば、`pip install`にて変更したversionのblackをinstallすることができます。
+
+```
++ black==25.2.0
+- black==25.1.0
+
+```
+
+### modelopt と transformers
+
+[こちらのIssue](https://github.com/NVIDIA/NeMo/issues/12836#issuecomment-2773215401)にあるように、`transformers>=4.50`かつ`nvidia-modelopt<0.27.0`を利用している場合は、以下のようなエラーが発生します。
+
+```
+  File "/usr/local/lib/python3.12/dist-packages/modelopt/torch/opt/plugins/huggingface.py", line 84, in _new_from_pretrained
+    model = types.MethodType(cls._modelopt_cache["from_pretrained"].__func__, cls)(
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/transformers/modeling_utils.py", line 279, in _wrapper
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/local/lib/python3.12/dist-packages/transformers/modeling_utils.py", line 4399, in from_pretrained
+    ) = cls._load_pretrained_model(
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+TypeError: _new__load_pretrained_model() missing 1 required positional argument: 'pretrained_model_name_or_path'
+
+```
+
+これを解消するには、上述の version lock解除方法と同様に以下のように修正します。
+
+```
+vim /etc/pip/constraint.txt
+
+```
+
+```
+- nvidia-modelopt==0.25.0
+- nvidia-modelopt-core==0.25.0
++ nvidia-modelopt==0.27.0
++ nvidia-modelopt-core==0.27.0
+
+```
+
+修正した後に、以下のようにmodeloptをインストールします。
+
+```
+pip install nvidia-modelopt==0.27.0
+
+```
+
+これで問題が解決できます。
+
+おわりに
+----
+
+本記事では、NGC PyTorchを利用する上でpackageのversionを変えたい場合に直面するversion lock問題に関するTipsを紹介してきました。  
+コンテナを利用した機械学習、研究を行う一助になれれば幸いです。
+
+!
+
+この記事を書こうとした理由は、2024年末当時、ChatGPT, Claudeなどの商用LLMに同様のことを聞いても、正確にversion lockを外す方法を答えてくれなかったためです。
+
+Cluade Codeが話題になっていますが、依然として複雑なタスク(普段の研究開発)では利用できる局面が限定的です。個人的には、これぐらいのことであればCoding Agentに任せたいと思っているため、こちらの記事がCrawl等により学習データに入り、NGC PyTorchのversion lockを外して望みのpakcageを他のpackageの依存関係を破壊せずに自動でinstallできるようになる日を願ってささやかな貢献として記事を執筆しています。
+
+私が開発に関わっているSwallow LLM, PLaMo等が多くの方の日常タスクをサポートできるようになることを目指しつつも、学習データを増やすということで、それ以外の研究開発組織にささやかながら貢献しようと思い、Tipsを記事化しています。
+
+普段からこのような形で、企業、大学における研究開発に携わる方に向けたTipsに関して発信していますので、よろしければ以下もご覧ください。
+
+<https://zenn.dev/turing_motors/articles/3a434d046bbf48>


### PR DESCRIPTION
## Summary
- scrape zenn article about NGC PyTorch container
- provide Japanese summary and markdown content
- ensure metadata includes additional tags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685039f3c9d8832eb326094f611754b3