### PR TITLE
Refine media link tests

### DIFF
--- a/tests/test_image_links.py
+++ b/tests/test_image_links.py
@@ -1,8 +1,8 @@
 import pathlib
 import re
 
-# 対応拡張子（画像）必要に応じて追加
-IMG_EXT = r"(?:png|jpe?g|gif|webp|svg)"
+# 対応拡張子（画像）: PNG / JPEG のみ
+IMG_EXT = r"(?:png|jpe?g)"
 
 INLINE_IMG_RE = re.compile(
     rf"!\[[^\]]*]\((https://[^)]+\.{IMG_EXT}(?:\?[^)]*)?)\)",
@@ -22,7 +22,7 @@ def test_image_links():
     Summary/ 配下の .md ファイルについて
     - https:// で始まる
     - 同じ行に ![任意](URL) 形式で書かれている
-    という 2 条件を画像リンクに対してチェックする
+    という 2 条件を PNG / JPEG 画像リンクに対してチェックする
     """
     errors: list[str] = []
 

--- a/tests/test_video_links.py
+++ b/tests/test_video_links.py
@@ -2,10 +2,10 @@ import pathlib
 import re
 
 # ── 拡張子定義 ──────────────────────────────────────────────
-VIDEO_EXT  = r"(?:mp4|mov|m3u8)"                     # 動画
-POSTER_EXT = r"(?:png|jpe?g|gif|webp|svg)"           # サムネイル画像
+VIDEO_EXT = r"(?:mp4|mov)"  # 動画
+POSTER_EXT = r"(?:png|jpe?g|gif|webp|svg)"  # サムネイル画像
 
-# ── 正しい動画リンク構文： [![alt](poster)](https://...video.xxx)
+# ── 正しい動画リンク構文： [![alt](poster)](https://...video.mp4|mov)
 CORRECT_VIDEO_LINK_RE = re.compile(
     rf"""\[!\[[^\]]*]\(      # [![alt](
           [^)]+\.{POSTER_EXT} #   poster 画像 URL
@@ -17,7 +17,7 @@ CORRECT_VIDEO_LINK_RE = re.compile(
     flags=re.IGNORECASE | re.VERBOSE,
 )
 
-# ── 動画 URL を含む丸かっこ ( https://... .mp4|mov|m3u8 )
+# ── 動画 URL を含む丸かっこ ( https://... .mp4|mov )
 PAREN_VIDEO_RE = re.compile(
     rf"\(([^)]+\.{VIDEO_EXT}(?:\?[^)]*)?)\)",
     flags=re.IGNORECASE,
@@ -31,7 +31,7 @@ def test_video_links():
     Summary/ 配下の .md ファイルについて
     1. 動画 URL は https:// で始まる
     2. 行内に [![alt](poster)](動画) 形式で書かれている
-    の両方を満たしているかを検証する
+    の両方を満たしているかを検証する (対象拡張子は mp4, mov)
     """
     errors: list[str] = []
 
@@ -49,9 +49,7 @@ def test_video_links():
                     errors.append(f"{md}:{lineno}: https ではない → {url}")
                 elif url not in correct_urls:
                     errors.append(
-                        f"{md}:{lineno}: "
-                        "[![alt](poster)](url) 形式ではない → "
-                        f"{url}"
+                        f"{md}:{lineno}: [![alt](poster)](url) 形式ではない → {url}"
                     )
 
     assert not errors, "動画リンクのフォーマットエラー:\n" + "\n".join(errors)


### PR DESCRIPTION
## Summary
- restrict `test_image_links` to PNG/JPEG
- restrict `test_video_links` to MP4/MOV

## Testing
- `pre-commit run --files tests/test_gif_links.py tests/test_image_links.py tests/test_video_links.py tests/test/gif.md tests/test/image.md tests/test/mp4.md`


------
https://chatgpt.com/codex/tasks/task_e_685296b2dd10832e889b4f4910dfa000