### PR TITLE
Add clip: arxiv test-time compute

### DIFF
--- a/Summary/2025/06/arxiv.org/2025-06-18_2506-12928.md
+++ b/Summary/2025/06/arxiv.org/2025-06-18_2506-12928.md
@@ -1,0 +1,47 @@
+---
+title: 'Scaling Test-time Compute for LLM Agents'
+source: https://arxiv.org/html/2506.12928
+author:
+  - arxiv.org
+published: ''
+fetched: '2025-06-18T11:08:06.498412+00:00'
+tags:
+  - codex
+  - arxiv
+image: 
+---
+
+## 要約
+
+本論文は、推論時に計算資源を増やして性能を向上させるテストタイムスケーリング(TTS)を言語エージェントに応用し、効果を体系的に調べた初の試みである。ATTSと名付けた枠組みでは、BoNなどの並列サンプリング、反省や自己改良を適切なタイミングで行う逐次改訂、リストワイズ評価を使った結果統合、複数エージェント協調によるロールアウト多様化を組み合わせる。複数タスクの詳細な比較実験から、BoNとリストワイズ評価が特に有効で、反省は失敗が多い局面で実施すべきこと、探索の幅を広げるほどタスク達成度が高まることを示し、エージェント強化の指針を提示した。これにより大規模モデルの利用コストを抑えつつ高精度を引き出せる可能性が示され、今後の研究に道筋をつける。
+
+## 本文
+
+###### Abstract
+
+Scaling test time compute has shown remarkable success in improving the reasoning abilities of large language models (LLMs).
+In this work, we conduct the first systematic exploration of applying test-time scaling methods to language agents and investigate the extent to which it improves their effectiveness.
+Specifically, we explore different test-time scaling strategies, including: (1) parallel sampling algorithms; (2) sequential revision strategies; (3) verifiers and merging methods; (4)strategies for diversifying rollouts.
+We carefully analyze and ablate the impact of different design strategies on applying test-time scaling on language agents, and have follow findings:
+1. Scaling test time compute could improve the performance of agents.
+2. Knowing when to reflect is important for agents.
+3. Among different verification and result merging approaches, the list-wise method performs best.
+4. Increasing diversified rollouts exerts a positive effect on the agent’s task performance.
+
+1 Introduction
+--------------
+
+Language agents demonstrate exceptional capabilities in various domains [[26](https://arxiv.org/html/2506.12928v1#bib.bib26), [33](https://arxiv.org/html/2506.12928v1#bib.bib33), [9](https://arxiv.org/html/2506.12928v1#bib.bib9), [5](https://arxiv.org/html/2506.12928v1#bib.bib5), [34](https://arxiv.org/html/2506.12928v1#bib.bib34), [35](https://arxiv.org/html/2506.12928v1#bib.bib35)].For example, LangChain[[24](https://arxiv.org/html/2506.12928v1#bib.bib24)] connects LLMs with various tools to solve different tasks in an end-to-end manner, while Meta-GPT[[9](https://arxiv.org/html/2506.12928v1#bib.bib9)] enables multiple AI Agents to take on different roles and collaborate to accomplish tasks. Recently, long-thinking models like O1 [[11](https://arxiv.org/html/2506.12928v1#bib.bib11)] and R1 [[8](https://arxiv.org/html/2506.12928v1#bib.bib8)] showcase excellent reasoning abilities of Large Language Models (LLMs). Recent approaches [[15](https://arxiv.org/html/2506.12928v1#bib.bib15), [18](https://arxiv.org/html/2506.12928v1#bib.bib18)] leverage the extended thinking capabilities of long-activation models for planning, code writing, tool calling, and completing complex tasks. However, despite LLMs’ strong capabilities, they still struggle to match human performance on complex search and reasoning tasks [[32](https://arxiv.org/html/2506.12928v1#bib.bib32), [12](https://arxiv.org/html/2506.12928v1#bib.bib12)]. This occurs due to remaining limitations in model capabilities, errors in task planning and question answering, and issues with complex tool calling abilities.
+
+Increasing computational resources during the inference phase greatly enhances LLMs’ performance. Some works [[19](https://arxiv.org/html/2506.12928v1#bib.bib19), [20](https://arxiv.org/html/2506.12928v1#bib.bib20)] improve model exploration during inference through different sampling strategies, achieving excellent scores in challenging areas like mathematical reasoning.Charlie Snell et al.[[25](https://arxiv.org/html/2506.12928v1#bib.bib25)] investigated the effects of scaling inference-time computational consumption, while Wei Xiong et al.[[31](https://arxiv.org/html/2506.12928v1#bib.bib31)] focused on enhancing model performance through self-correction methods. However, directly applying TTS methods to the Agentic Framework presents many challenges.
+Unlike LLMs that solve specific problems in an end-to-end manner, Agents typically decompose complex problems into distinct steps, invoking multiple models sequentially for resolution. Due to the extended sequence of steps and the accumulation of errors, traditional TTS methods (e.g., BoN) can significantly undermine the final outcome, because they randomly generate N responses at each step.
+
+To address the aforementioned challenges, we first conduct a systematic exploration of test-time scaling methods for language agents. First, we investigate the effectiveness of different **parallel sampling** methods for agentic test-time scaling, including variants of Best-of-N (BoN), beam search, and tree search algorithms. We adapt and implement these parallel sampling mechanisms within language agents and showing that despite simplicity, BoN achieves the optimal performance. Subsequently, we investigate the effectiveness of various **sequential revision** techniques, such as reflection and self-refinement, for language agents. We introduce a reflection agent to summarize and reflect based on the current state and recent actions/observations to help the agent consistently progress toward accomplishing the task. Experimental results show that the direct gains from having the agent perform reflection at each step are not obvious. Instead, allowing the agent to perform reflection when it performs poorly in the current step brings certain benefits. This indicates that **knowing when the agent should reflect is more important than having the agent perform reflection at every step directly**.
+Finally, we conduct a detailed study on the impact of different verify and result merging methods, including voting, scoring, and list-wise approaches. Our experimental results demonstrate that whether for merge results methods or verify methods, **using the list-wise method outperforms other methods**. This provides an effective verify method reference for agentic frameworks.
+Finally, we test different strategies to expand the agent’s exploration space and enhance the diversity of different rollouts, and propose a multi-agent collaborative sampling strategy. Experimental results indicate that performance under multi-agent collaboration surpasses that of a single agent.
+
+Our core contributions are:
+
+* We explore the application of different parallel sampling strategies in agentic frameworks. Through parallel sampling strategies, agent performance can be significantly improved.
+* We study the impact of sequential revision techniques in agentic frameworks. In particular, we point out that it is very important for agents to know when they should perform revision.
+* We also conduct detailed comparative analysis of different verify and result merge strategies. Experiments show that the list-wise method significantly outperforms other methods.


### PR DESCRIPTION
## Summary
- scrape arXiv page on scaling test-time compute for LLM agents
- save markdown clip with metadata and Japanese summary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529d8f2e00832eb314b5caa1499b3f