### PR TITLE
Add clip: Ring-lite arXiv paper

### DIFF
--- a/Summary/2025/06/arxiv.org/2025-06-17_2506-14731.md
+++ b/Summary/2025/06/arxiv.org/2025-06-17_2506-14731.md
@@ -1,0 +1,47 @@
+---
+title: 'Ring-lite: Scalable Reasoning via C3PO-Stabilized Reinforcement Learning for LLMs'
+source: https://arxiv.org/html/2506.14731
+author:
+  - arxiv.org
+published: '2025-06-17T00:00:00+00:00'
+fetched: '2025-06-18T11:21:04.045381+00:00'
+tags:
+  - codex
+  - arxiv
+image: 
+---
+
+## 要約
+
+Ring-liteはMixture-of-Experts(MoE)を用いる大規模言語モデルを強化学習で効果的かつ安定的に訓練する手法。公開済みのLing-liteを土台に総パラメータ16.8Bで実働2.75Bという軽量構成ながら、AIMEやLiveCodeBenchなど難度の高いベンチマークでSOTAレベルを実現する。蒸留とRLを統合したパイプラインを採用し、学習の不安定さを解消するため**C3PO**法を導入。さらに**エントロピー損失**に基づくチェックポイント選択や二段階学習で多領域データを調和させ、高効率で汎化性の高い推論モデルを構築した。モデル・データセット・コードも公開予定で、MoE×RL研究を加速する。
+
+## 本文
+
+**G**roup **R**elative **P**olicy **O**ptimization (**GRPO**) algorithm is widely used such as DeepSeek-R1, Qwen3 and so on. For each question-answer pair (q,a)𝑞𝑎(q,a)( italic\_q , italic\_a ) in the training dataset 𝒟𝒟\mathcal{D}caligraphic\_D, we generate
+K𝐾Kitalic\_K responses (i.i.d.) through the policy model πθoldsubscript𝜋subscript𝜃old\pi\_{\theta\_{\text{old}}}italic\_π start\_POSTSUBSCRIPT italic\_θ start\_POSTSUBSCRIPT old end\_POSTSUBSCRIPT end\_POSTSUBSCRIPT. The reward Risubscript𝑅𝑖R\_{i}italic\_R start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT of the response yisubscript𝑦𝑖y\_{i}italic\_y start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT is determined by the reward model or rule-based verifier.
+GRPO estimates the advantage via group-normalized rewards instead of the value model, Ai,t=Ri−mean⁢({Ri}i=1K)std⁢({Ri}i=1K)subscript𝐴
+
+𝑖𝑡subscript𝑅𝑖meansuperscriptsubscriptsubscript𝑅𝑖𝑖1𝐾stdsuperscriptsubscriptsubscript𝑅𝑖𝑖1𝐾{A}\_{i,t}=\frac{R\_{i}-\text{mean}(\{R\_{i}\}\_{i=1}^{K})}{\text{std}(\{R\_{i}\}\_{%
+i=1}^{K})}italic\_A start\_POSTSUBSCRIPT italic\_i , italic\_t end\_POSTSUBSCRIPT = divide start\_ARG italic\_R start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT - mean ( { italic\_R start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT } start\_POSTSUBSCRIPT italic\_i = 1 end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_K end\_POSTSUPERSCRIPT ) end\_ARG start\_ARG std ( { italic\_R start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT } start\_POSTSUBSCRIPT italic\_i = 1 end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_K end\_POSTSUPERSCRIPT ) end\_ARG. Specifically, the GRPO loss is formulated as:
+
+|  |  |  |  |  |
+| --- | --- | --- | --- | --- |
+|  | ℒGRPO⁢(θ)subscriptℒGRPO𝜃\displaystyle\mathcal{L}\_{\text{GRPO}}(\theta)caligraphic\_L start\_POSTSUBSCRIPT GRPO end\_POSTSUBSCRIPT ( italic\_θ ) | =−𝔼(q,a)∼𝒟,{yi}i=1K∼πθold(⋅∣q)\displaystyle=-\mathbb{E}\_{(q,a)\sim\mathcal{D},\{y\_{i}\}\_{i=1}^{K}\sim\pi\_{% \theta\_{\text{old}}}(\cdot\mid q)}= - blackboard\_E start\_POSTSUBSCRIPT ( italic\_q , italic\_a ) ∼ caligraphic\_D , { italic\_y start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT } start\_POSTSUBSCRIPT italic\_i = 1 end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_K end\_POSTSUPERSCRIPT ∼ italic\_π start\_POSTSUBSCRIPT italic\_θ start\_POSTSUBSCRIPT old end\_POSTSUBSCRIPT end\_POSTSUBSCRIPT ( ⋅ ∣ italic\_q ) end\_POSTSUBSCRIPT |  | (1) |
+|  |  | [1K∑i=1K1|yi|∑t=1|yi|(min(ri,t(θ)Ai,t,clip(ri,t(θ),1−ε,1+ε)Ai,t)−βDKL(πθ||πref))],\displaystyle\Bigg{[}\frac{1}{K}\sum\_{i=1}^{K}\frac{1}{|y\_{i}|}\sum\_{t=1}^{|y\_% {i}|}\Bigg{(}\min\Big{(}r\_{i,t}(\theta){A}\_{i,t},\ \ \text{clip}\Big{(}r\_{i,t}% (\theta),1-\varepsilon,1+\varepsilon\Big{)}{A}\_{i,t}\Big{)}-\beta D\_{\text{KL}% }(\pi\_{\theta}||\pi\_{\text{ref}})\Bigg{)}\Bigg{]},[ divide start\_ARG 1 end\_ARG start\_ARG italic\_K end\_ARG ∑ start\_POSTSUBSCRIPT italic\_i = 1 end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_K end\_POSTSUPERSCRIPT divide start\_ARG 1 end\_ARG start\_ARG | italic\_y start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT | end\_ARG ∑ start\_POSTSUBSCRIPT italic\_t = 1 end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT | italic\_y start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT | end\_POSTSUPERSCRIPT ( roman\_min ( italic\_r start\_POSTSUBSCRIPT italic\_i , italic\_t end\_POSTSUBSCRIPT ( italic\_θ ) italic\_A start\_POSTSUBSCRIPT italic\_i , italic\_t end\_POSTSUBSCRIPT , clip ( italic\_r start\_POSTSUBSCRIPT italic\_i , italic\_t end\_POSTSUBSCRIPT ( italic\_θ ) , 1 - italic\_ε , 1 + italic\_ε ) italic\_A start\_POSTSUBSCRIPT italic\_i , italic\_t end\_POSTSUBSCRIPT ) - italic\_β italic\_D start\_POSTSUBSCRIPT KL end\_POSTSUBSCRIPT ( italic\_π start\_POSTSUBSCRIPT italic\_θ end\_POSTSUBSCRIPT | | italic\_π start\_POSTSUBSCRIPT ref end\_POSTSUBSCRIPT ) ) ] , |  |
+
+where ri,t⁢(θ)=πθ⁢(yi,t∣q,yi,<t)πθold⁢(yi,t∣q,yi,<t)subscript𝑟
+
+𝑖𝑡𝜃subscript𝜋𝜃conditionalsubscript𝑦
+
+𝑖𝑡
+
+𝑞subscript𝑦
+
+𝑖absent𝑡subscript𝜋subscript𝜃oldconditionalsubscript𝑦
+
+𝑖𝑡
+
+𝑞subscript𝑦
+
+𝑖absent𝑡r\_{i,t}(\theta)=\frac{\pi\_{\theta}(y\_{i,t}\mid q,y\_{i,<t})}{\pi\_{\theta\_{\text%
+{old}}}(y\_{i,t}\mid q,y\_{i,<t})}italic\_r start\_POSTSUBSCRIPT italic\_i , italic\_t end\_POSTSUBSCRIPT ( italic\_θ ) = divide start\_ARG italic\_π start\_POSTSUBSCRIPT italic\_θ end\_POSTSUBSCRIPT ( italic\_y start\_POSTSUBSCRIPT italic\_i , italic\_t end\_POSTSUBSCRIPT ∣ italic\_q , italic\_y start\_POSTSUBSCRIPT italic\_i , < italic\_t end\_POSTSUBSCRIPT ) end\_ARG start\_ARG italic\_π start\_POSTSUBSCRIPT italic\_θ start\_POSTSUBSCRIPT old end\_POSTSUBSCRIPT end\_POSTSUBSCRIPT ( italic\_y start\_POSTSUBSCRIPT italic\_i , italic\_t end\_POSTSUBSCRIPT ∣ italic\_q , italic\_y start\_POSTSUBSCRIPT italic\_i , < italic\_t end\_POSTSUBSCRIPT ) end\_ARG and ε𝜀\varepsilonitalic\_ε is the clip bound. DKL(πθ||πref)D\_{\text{KL}}(\pi\_{\theta}||\pi\_{\text{ref}})italic\_D start\_POSTSUBSCRIPT KL end\_POSTSUBSCRIPT ( italic\_π start\_POSTSUBSCRIPT italic\_θ end\_POSTSUBSCRIPT | | italic\_π start\_POSTSUBSCRIPT ref end\_POSTSUBSCRIPT ) is the token-level KL loss, keeping the policy model πθsubscript𝜋𝜃\pi\_{\theta}italic\_π start\_POSTSUBSCRIPT italic\_θ end\_POSTSUBSCRIPT not far from the reference policy πr⁢e⁢fsubscript𝜋𝑟𝑒𝑓\pi\_{ref}italic\_π start\_POSTSUBSCRIPT italic\_r italic\_e italic\_f end\_POSTSUBSCRIPT.

--- a/python_tools/scrape.py
+++ b/python_tools/scrape.py
@@ -143,6 +143,15 @@ if html is not None:
                 else:
                     dt = datetime.strptime(f"{day} {month_name} {year}", "%d %B %Y")
                 published = dt.replace(tzinfo=timezone.utc).isoformat()
+    if not published:
+        date_div = soup.find("div", class_="ltx_dates")
+        if isinstance(date_div, Tag):
+            text = date_div.get_text(strip=True).strip("()")
+            try:
+                dt = datetime.strptime(text, "%b %d, %Y")
+                published = dt.replace(tzinfo=timezone.utc).isoformat()
+            except Exception:
+                pass
     image = get_meta(soup, "og:image")
 fetched = datetime.now(timezone.utc).isoformat()
 source = url


### PR DESCRIPTION
## Summary
- parse `ltx_dates` for date on arXiv HTML
- add web clip for `Ring-lite: Scalable Reasoning via C3PO-Stabilized Reinforcement Learning for LLMs`

## Testing
- `pre-commit run --files python_tools/scrape.py Summary/2025/06/arxiv.org/2025-06-17_2506-14731.md`

------
https://chatgpt.com/codex/tasks/task_e_6852a0978c0c832ea0f3a7f432beb63a