### PR TITLE
Move efficiency test to tests folder

### DIFF
--- a/tests/test_author.py
+++ b/tests/test_author.py
@@ -16,7 +16,9 @@ def test_author_field():
         except ValueError:
             continue
 
-        meta = yaml.load("\n".join(lines[start + 1 : end]), Loader=yaml.BaseLoader) or {}
+        meta = (
+            yaml.load("\n".join(lines[start + 1 : end]), Loader=yaml.BaseLoader) or {}
+        )
         author_field = meta.get("author", [])
         if not isinstance(author_field, list):
             errors.append(f"{md}: author フィールドは箇条書きで記述してください")
@@ -26,7 +28,9 @@ def test_author_field():
         source = str(meta.get("source", "")).strip()
 
         if not authors:
-            errors.append(f"{md}: author が空白です。個人名が望ましい。なければドメイン名を入力してください")
+            errors.append(
+                f"{md}: author が空白です。個人名が望ましい。なければドメイン名を入力してください"
+            )
             continue
 
         if not source:

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -2,45 +2,46 @@
 """
 Simple verification script to test the efficiency improvements.
 """
+
 import time
 import sys
-import os
 from urllib.parse import urlparse
+
 
 def test_fetch_function():
     """Test the new fetch_with_fallback function"""
     try:
-        sys.argv = ['test_efficiency.py', 'https://example.com']
-        sys.path.append('python_tools')
-        from scrape import fetch_with_fallback
-        
+        sys.argv = ["test_efficiency.py", "https://example.com"]
+        from python_tools.scrape import fetch_with_fallback
+
         test_url = "https://httpbin.org/get"
         parsed = urlparse(test_url)
-        
+
         print(f"Testing fetch_with_fallback with: {test_url}")
         start_time = time.time()
-        
+
         try:
             response, used_proxy = fetch_with_fallback(test_url, parsed)
             end_time = time.time()
-            
+
             print(f"✅ Fetch completed in {end_time - start_time:.2f}s")
             print(f"   Used proxy: {used_proxy}")
             print(f"   Response length: {len(response)} characters")
             return True
-            
+
         except Exception as e:
             print(f"❌ Fetch failed: {e}")
             return False
-            
+
     except ImportError as e:
         print(f"❌ Import failed: {e}")
         return False
 
+
 if __name__ == "__main__":
     print("=== Efficiency Test Script ===")
     success = test_fetch_function()
-    
+
     if success:
         print("\n✅ All efficiency tests passed!")
         sys.exit(0)

--- a/tests/test_format_check.py
+++ b/tests/test_format_check.py
@@ -1,10 +1,10 @@
 import pathlib
 import yaml
-import pytest
 
 # ── 設定 ──────────────────────────────────────────────────────────────
 SUMMARY_DIR = pathlib.Path("Summary")  # ここだけ指定すれば OK
 MAX_IMAGE_BYTES = 1600  # image URL 長さの上限
+
 
 # ── テスト本体 ────────────────────────────────────────────────────────
 def test_formatting():
@@ -12,25 +12,33 @@ def test_formatting():
 
     # Summary 配下をすべて対象にする
     for md in SUMMARY_DIR.rglob("*.md"):
-        text  = md.read_text(encoding="utf-8")
+        text = md.read_text(encoding="utf-8")
         lines = text.splitlines()
 
         # ------ セクション見出しチェック ------------------------------
-        body_lines = [l.strip() for l in lines if l.strip().startswith("## 本文")]
+        body_lines = [
+            line_.strip() for line_ in lines if line_.strip().startswith("## 本文")
+        ]
         if not body_lines:
             errors.append(f"{md}: 正しいセクション名は '## 本文'")
         else:
-            for l in body_lines:
-                if l != "## 本文":
-                    errors.append(f"{md}: '## 本文' の行に余計な文字があります: '{l}'")
+            for line_ in body_lines:
+                if line_ != "## 本文":
+                    errors.append(
+                        f"{md}: '## 本文' の行に余計な文字があります: '{line_}'"
+                    )
 
-        summary_lines = [l.strip() for l in lines if l.strip().startswith("## 要約")]
+        summary_lines = [
+            line_.strip() for line_ in lines if line_.strip().startswith("## 要約")
+        ]
         if not summary_lines:
             errors.append(f"{md}: 正しいセクション名は '## 要約'")
         else:
-            for l in summary_lines:
-                if l != "## 要約":
-                    errors.append(f"{md}: '## 要約' の行に余計な文字があります: '{l}'")
+            for line_ in summary_lines:
+                if line_ != "## 要約":
+                    errors.append(
+                        f"{md}: '## 要約' の行に余計な文字があります: '{line_}'"
+                    )
 
         # ------ メタデータ抽出 --------------------------------------
         meta: dict[str, str] = {}
@@ -58,12 +66,16 @@ def test_formatting():
         if "codex" not in tags:
             errors.append(f"{md}: 必須タグ 'codex' が抜けています")
         elif tags == ["codex"]:
-            errors.append(f"{md}: 'codex' 以外に関連タグを少なくとも 1 つ追加してください。どんなタグが適切か考えてみてください")
+            errors.append(
+                f"{md}: 'codex' 以外に関連タグを少なくとも 1 つ追加してください。どんなタグが適切か考えてみてください"
+            )
 
         # ------ image URL 長さチェック ------------------------------
         image = meta.get("image", "")
         if image and len(image.encode("utf-8")) > MAX_IMAGE_BYTES:
-            errors.append(f"{md}: image URL が {MAX_IMAGE_BYTES} バイトを超えています。`image:` フィールドを空にしてください")
+            errors.append(
+                f"{md}: image URL が {MAX_IMAGE_BYTES} バイトを超えています。`image:` フィールドを空にしてください"
+            )
 
     # 1 件でもあれば失敗
     assert not errors, "フォーマットエラー:\n" + "\n".join(errors)


### PR DESCRIPTION
## Summary
- move `test_efficiency.py` into the `tests` directory
- switch to package import for `fetch_with_fallback`
- ensure format tests pass by cleaning variable names
- add empty `python_tools/__init__.py`

## Testing
- `pre-commit run --files tests/test_efficiency.py tests/test_author.py tests/test_format_check.py tests/test_video_links.py tests/test_gif_links.py tests/test_image_links.py tests/test_domain_folder.py python_tools/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6855394b375c832e85e38335d0fc76c4