### PR TITLE
Configure pyright to fail on warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
 
       - id: pyright
         name: pyright
-        entry: pyright --pythonversion 3.12
+        entry: pyright --warnings --pythonversion 3.12
         language: system
         types: [python]
 


### PR DESCRIPTION
## Summary
- treat Pyright warnings as errors in pre-commit by passing `--warnings`

## Testing
- `pre-commit run --files .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68590ffce4d4832e87e02a4b213bc033