### PR TITLE
Add clip for StreamDiT paper

### DIFF
--- a/Summary/2025/07/arxiv.org/2025-07-09_2507-03745v2.md
+++ b/Summary/2025/07/arxiv.org/2025-07-09_2507-03745v2.md
@@ -1,0 +1,128 @@
+---
+title: 'StreamDiT: Real-Time Streaming Text-to-Video Generation'
+source: https://arxiv.org/html/2507.03745v2
+author:
+  - Akio Kodaira
+  - Tingbo Hou
+  - Ji Hou
+  - Masayoshi Tomizuka
+  - Yue Zhao
+published: '2025-07-08T00:00:00Z'
+fetched: '2025-07-09T07:46:43.534086+00:00'
+tags:
+  - codex
+  - arxiv
+image: https://arxiv.org/static/browse/0.3.4/images/arxiv-logo-fb.png
+---
+
+## 要約
+
+近年、拡散モデルを大規模化することで高品質なテキスト条件付き動画生成が可能になったが、従来手法は短いクリップしか生成できず、対話的・リアルタイム用途には不向きだった。本論文では、フローマッチングに動的バッファを導入し、フレーム分割を組み合わせた学習法で時間的一貫性と画質を向上させるStreamDiTを提案する。4Bパラメータモデルを学習し、分割毎に行う多段蒸留により推論回数をバッファのチャンク数まで削減した。1GPUで512p動画を毎秒16フレーム生成でき、実時間でのストリーミングやインタラクティブ生成を実現する。定量指標と人手評価でも優れた性能を示し、Web上で動画例を公開している。本研究により長尺動画生成の新たな可能性が開かれた。
+
+## 本文
+
+### 3.1 Buffered Flow Matching
+
+**Flow Matching:** Our method is based on the Flow Matching (FM) [[24](https://arxiv.org/html/2507.03745v2#bib.bib24)] framework for training.
+FM produces a sample from the target data distribution by progressively transforming a sample from an initial prior distribution, such as a Gaussian.
+During training, for a data sample denoted as 𝐗1subscript𝐗1\mathbf{X}\_{1}bold\_X start\_POSTSUBSCRIPT 1 end\_POSTSUBSCRIPT, we sample a time step t∈[0,1]𝑡01t\in[0,1]italic\_t ∈ [ 0 , 1 ], and noise 𝐗0∼𝒩⁢(0,1)similar-tosubscript𝐗0𝒩01\mathbf{X}\_{0}\sim\mathcal{N}(0,1)bold\_X start\_POSTSUBSCRIPT 0 end\_POSTSUBSCRIPT ∼ caligraphic\_N ( 0 , 1 ). These are then used to create a training sample 𝐗tsubscript𝐗𝑡\mathbf{X}\_{t}bold\_X start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT.
+FM predicts the velocity 𝐕tsubscript𝐕𝑡\mathbf{V}\_{t}bold\_V start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT that moves the sample 𝐗tsubscript𝐗𝑡\mathbf{X}\_{t}bold\_X start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT in the direction of data sample 𝐗1subscript𝐗1\mathbf{X}\_{1}bold\_X start\_POSTSUBSCRIPT 1 end\_POSTSUBSCRIPT.
+
+A simple linear interpolation or the optimal transport (OT) path [[24](https://arxiv.org/html/2507.03745v2#bib.bib24)] is used to construct 𝐱tsubscript𝐱𝑡\mathbf{x}\_{t}bold\_x start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT, *i.e*.,
+
+|  |  |  |  |
+| --- | --- | --- | --- |
+|  | 𝐗t=t⁢𝐗1+(1−(1−σmin)⁢t)⁢𝐗0,subscript𝐗𝑡𝑡subscript𝐗111subscript𝜎min𝑡subscript𝐗0\mathbf{X}\_{t}=t~{}\mathbf{X}\_{1}+(1-(1-\sigma\_{\mathrm{min}})t)~{}\mathbf{X}\_% {0},bold\_X start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT = italic\_t bold\_X start\_POSTSUBSCRIPT 1 end\_POSTSUBSCRIPT + ( 1 - ( 1 - italic\_σ start\_POSTSUBSCRIPT roman\_min end\_POSTSUBSCRIPT ) italic\_t ) bold\_X start\_POSTSUBSCRIPT 0 end\_POSTSUBSCRIPT , |  | (1) |
+
+where σminsubscript𝜎min\sigma\_{\mathrm{min}}italic\_σ start\_POSTSUBSCRIPT roman\_min end\_POSTSUBSCRIPT is the standard deviation of x𝑥xitalic\_x at t=1𝑡1t=1italic\_t = 1.
+Thus, the ground truth velocity can be derived as
+
+|  |  |  |  |
+| --- | --- | --- | --- |
+|  | 𝐕t=d⁢𝐗td⁢t=𝐗1−(1−σmin)⁢𝐗0.subscript𝐕𝑡𝑑subscript𝐗𝑡𝑑𝑡subscript𝐗11subscript𝜎minsubscript𝐗0\mathbf{V}\_{t}=\dfrac{d\mathbf{X}\_{t}}{dt}=\mathbf{X}\_{1}-(1-\sigma\_{\mathrm{% min}})\mathbf{X}\_{0}.bold\_V start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT = divide start\_ARG italic\_d bold\_X start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT end\_ARG start\_ARG italic\_d italic\_t end\_ARG = bold\_X start\_POSTSUBSCRIPT 1 end\_POSTSUBSCRIPT - ( 1 - italic\_σ start\_POSTSUBSCRIPT roman\_min end\_POSTSUBSCRIPT ) bold\_X start\_POSTSUBSCRIPT 0 end\_POSTSUBSCRIPT . |  | (2) |
+
+It is worth noting that this target is irrelevant to time step t𝑡titalic\_t.
+With parameters ΘΘ\Thetaroman\_Θ and text prompt 𝐏𝐏\mathbf{P}bold\_P, the predicted velocity is written as u⁢(𝐗t,𝐏,t;Θ)𝑢subscript𝐗𝑡𝐏𝑡Θu(\mathbf{X}\_{t},\mathbf{P},t;\Theta)italic\_u ( bold\_X start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT , bold\_P , italic\_t ; roman\_Θ ), and the training objective is represented as
+
+|  |  |  |  |
+| --- | --- | --- | --- |
+|  | 𝔼t,𝐗t⁢‖u⁢(𝐗t,𝐏,t;Θ)−𝐕t‖2.subscript𝔼  𝑡subscript𝐗𝑡superscriptnorm𝑢subscript𝐗𝑡𝐏𝑡Θsubscript𝐕𝑡2\mathbb{E}\_{t,\mathbf{X}\_{t}}\|u(\mathbf{X}\_{t},\mathbf{P},t;\Theta)-\mathbf{V% }\_{t}\|^{2}.blackboard\_E start\_POSTSUBSCRIPT italic\_t , bold\_X start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT end\_POSTSUBSCRIPT ∥ italic\_u ( bold\_X start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT , bold\_P , italic\_t ; roman\_Θ ) - bold\_V start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT ∥ start\_POSTSUPERSCRIPT 2 end\_POSTSUPERSCRIPT . |  | (3) |
+
+At inference, an FM model predicts the velocity to a clean sample on every denoising step. With the Euler solver, the inference can be formulated as
+
+|  |  |  |  |
+| --- | --- | --- | --- |
+|  | 𝐗t+Δ⁢t=𝐗t+u⁢(𝐗t,𝐏,t;Θ)⁢Δ⁢t,subscript𝐗𝑡Δ𝑡subscript𝐗𝑡𝑢subscript𝐗𝑡𝐏𝑡ΘΔ𝑡\mathbf{X}\_{t+\Delta t}=\mathbf{X}\_{t}+u(\mathbf{X}\_{t},\mathbf{P},t;\Theta)% \Delta t,bold\_X start\_POSTSUBSCRIPT italic\_t + roman\_Δ italic\_t end\_POSTSUBSCRIPT = bold\_X start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT + italic\_u ( bold\_X start\_POSTSUBSCRIPT italic\_t end\_POSTSUBSCRIPT , bold\_P , italic\_t ; roman\_Θ ) roman\_Δ italic\_t , |  | (4) |
+
+where Δ⁢tΔ𝑡\Delta troman\_Δ italic\_t is the step size.
+
+**Buffered Flow Matching:** We consider streaming video generation as a sequence of (possibly latent) frames [f1,f2,…,fN]
+
+subscript𝑓1subscript𝑓2…subscript𝑓𝑁[f\_{1},f\_{2},\dots,f\_{N}][ italic\_f start\_POSTSUBSCRIPT 1 end\_POSTSUBSCRIPT , italic\_f start\_POSTSUBSCRIPT 2 end\_POSTSUBSCRIPT , … , italic\_f start\_POSTSUBSCRIPT italic\_N end\_POSTSUBSCRIPT ], and N𝑁Nitalic\_N can be infinite. For a video diffusion model with frame buffer B𝐵Bitalic\_B, the clean data sample starting with frame fisubscript𝑓𝑖f\_{i}italic\_f start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT is denoted as 𝐗1i=[fi,…,fi+B]superscriptsubscript𝐗1𝑖
+
+subscript𝑓𝑖…subscript𝑓𝑖𝐵\mathbf{X}\_{1}^{i}=[f\_{i},\dots,f\_{i+B}]bold\_X start\_POSTSUBSCRIPT 1 end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_i end\_POSTSUPERSCRIPT = [ italic\_f start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT , … , italic\_f start\_POSTSUBSCRIPT italic\_i + italic\_B end\_POSTSUBSCRIPT ]. We allow different noise levels to the frames: τ=[τ1,…,τB]𝜏
+
+subscript𝜏1…subscript𝜏𝐵\tau=[\tau\_{1},\dots,\tau\_{B}]italic\_τ = [ italic\_τ start\_POSTSUBSCRIPT 1 end\_POSTSUBSCRIPT , … , italic\_τ start\_POSTSUBSCRIPT italic\_B end\_POSTSUBSCRIPT ] as a monotonically increasing sequence. Thus a training example can be constructed as
+
+|  |  |  |  |
+| --- | --- | --- | --- |
+|  | 𝐗τi=τ∘𝐗1i+(1−(1−σmin)⁢τ)∘𝐗0,superscriptsubscript𝐗𝜏𝑖𝜏superscriptsubscript𝐗1𝑖11subscript𝜎min𝜏subscript𝐗0\mathbf{X}\_{\tau}^{i}=\tau\circ~{}\mathbf{X}\_{1}^{i}+(1-(1-\sigma\_{\mathrm{min% }})\tau)\circ~{}\mathbf{X}\_{0},bold\_X start\_POSTSUBSCRIPT italic\_τ end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_i end\_POSTSUPERSCRIPT = italic\_τ ∘ bold\_X start\_POSTSUBSCRIPT 1 end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_i end\_POSTSUPERSCRIPT + ( 1 - ( 1 - italic\_σ start\_POSTSUBSCRIPT roman\_min end\_POSTSUBSCRIPT ) italic\_τ ) ∘ bold\_X start\_POSTSUBSCRIPT 0 end\_POSTSUBSCRIPT , |  | (5) |
+
+where ∘\circ∘ denotes element-wise product. Please note that the noise sample X0subscript𝑋0X\_{0}italic\_X start\_POSTSUBSCRIPT 0 end\_POSTSUBSCRIPT remains the same.
+
+At inference, the buffer is updated by model predicted flow
+
+|  |  |  |  |
+| --- | --- | --- | --- |
+|  | 𝐗τ+Δ⁢τi=𝐗τi+u⁢(𝐗τi,𝐏,τ;Θ)∘Δ⁢τ,superscriptsubscript𝐗𝜏Δ𝜏𝑖superscriptsubscript𝐗𝜏𝑖𝑢superscriptsubscript𝐗𝜏𝑖𝐏𝜏ΘΔ𝜏\mathbf{X}\_{\tau+\Delta\tau}^{i}=\mathbf{X}\_{\tau}^{i}+u(\mathbf{X}\_{\tau}^{i}% ,\mathbf{P},\tau;\Theta)\circ\Delta\tau,bold\_X start\_POSTSUBSCRIPT italic\_τ + roman\_Δ italic\_τ end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_i end\_POSTSUPERSCRIPT = bold\_X start\_POSTSUBSCRIPT italic\_τ end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_i end\_POSTSUPERSCRIPT + italic\_u ( bold\_X start\_POSTSUBSCRIPT italic\_τ end\_POSTSUBSCRIPT start\_POSTSUPERSCRIPT italic\_i end\_POSTSUPERSCRIPT , bold\_P , italic\_τ ; roman\_Θ ) ∘ roman\_Δ italic\_τ , |  | (6) |
+
+where Δ⁢τΔ𝜏\Delta\tauroman\_Δ italic\_τ is a sequence of step sizes. If one or more frames achieve the final denoising step, they are popped out of the buffer, and new noise frames are pushed at the beginning of the buffer. Therefore, it can generate streaming video sequences.
+
+### 3.2 Partitioning Scheme
+
+![Refer to caption](https://arxiv.org/html/2507.03745v2/x2.png)
+
+
+Figure 2: Illustration of StreamDiT partitioning. We partition the buffer to K𝐾Kitalic\_K reference frames and N𝑁Nitalic\_N chunks. Each chunk has c𝑐citalic\_c frames and s𝑠sitalic\_s micro denoising steps.
+
+To facilitate flexible training and inference of StreamDiT, we design a unified partitioning of buffered frames. As illustrated in [Fig. 2](https://arxiv.org/html/2507.03745v2#S3.F2 "In 3.2 Partitioning Scheme ‣ 3 StreamDiT Training ‣ StreamDiT: Real-Time Streaming Text-to-Video Generation"), the buffer is partitioned to K𝐾Kitalic\_K reference frames and N𝑁Nitalic\_N chunks. Each chunk has c𝑐citalic\_c frames and s𝑠sitalic\_s micro denoising steps.
+
+**Clean Reference Frames:**
+To enhance temporal consistency, we can optionally cache the last K𝐾Kitalic\_K fully denoised frames at the beginning of the buffer. We refer to these clean frames of as reference frames. They participate in the denoising step as input but are no longer denoised. The reference frames are updated in the same way as other frames when the buffer moves. Allowing optional reference frames matches the design of FIFO-Diffusion [[20](https://arxiv.org/html/2507.03745v2#bib.bib20)], which can be viewed as a special case. Since our method is trainable, we found that reference frames can be skipped for streaming video generation. Hence, we set K=0𝐾0K=0italic\_K = 0 in the rest of our work.
+
+**Chunked Denoising:**
+Instead of denoising frame by frame, we group frames into stream chunks, with each chunk containing a specified number of frames indicated by chunk size. Noise levels are now applied at the chunk level, and each time a chunk of frames exits the pipeline.
+Let N𝑁Nitalic\_N denote the number of stream chunks and c𝑐citalic\_c the number of frames in each chunk. Then the total number of frames processed at any time is K+N×c𝐾𝑁𝑐K+N\times citalic\_K + italic\_N × italic\_c, and the number of denoising steps is constrained to N𝑁Nitalic\_N.
+
+**Micro Step:**
+As the total number of denoising steps is bounded by N𝑁Nitalic\_N, however, for better performance, additional denoising steps are usually necessary. A straightforward approach to address this limitation is to increase the size of the buffer, but this is limited by the maximum capacity of the model to denoise frames and would also increase latency for each frame in the buffer.
+
+To overcome this, we introduce an additional dimension of the design called micro-denoising step, illustrated in [Fig. 2](https://arxiv.org/html/2507.03745v2#S3.F2 "In 3.2 Partitioning Scheme ‣ 3 StreamDiT Training ‣ StreamDiT: Real-Time Streaming Text-to-Video Generation"). The core idea of micro step is to denoise stream chunks along the temporal axis while stagnating at a fixed spatial position for certain time. Let s𝑠sitalic\_s denote the denoising steps per micro step; then each stream chunk undergoes s𝑠sitalic\_s denoising steps before advancing to the next noise level and moving toward the output. This modification effectively extends the total number of denoising steps to s×N𝑠𝑁s\times Nitalic\_s × italic\_N without increasing the buffer size.
+
+With the incorporation of reference frames, chunked frames, and micro-step denoising, the following equations hold:
+
+|  |  |  |  |
+| --- | --- | --- | --- |
+|  | B=K+N×cT=s×N𝐵𝐾𝑁𝑐𝑇𝑠𝑁\begin{split}B&=K+N\times c\\ T&=s\times N\end{split}start\_ROW start\_CELL italic\_B end\_CELL start\_CELL = italic\_K + italic\_N × italic\_c end\_CELL end\_ROW start\_ROW start\_CELL italic\_T end\_CELL start\_CELL = italic\_s × italic\_N end\_CELL end\_ROW |  | (7) |
+
+where B𝐵Bitalic\_B is the total length of the frame fed into the model, N𝑁Nitalic\_N is the number of stream chunks, c𝑐citalic\_c is the number of frames in each stream chunk, and T𝑇Titalic\_T represents the total number of inference denoising steps.
+
+|  |  |  |  |
+| --- | --- | --- | --- |
+| Method | Scheme | Consistency | Streaming |
+| Uniform | c=B,s=1formulae-sequence𝑐𝐵𝑠1c=B,s=1italic\_c = italic\_B , italic\_s = 1 | High | No |
+| Diagonal | c=1,s=1formulae-sequence𝑐1𝑠1c=1,s=1italic\_c = 1 , italic\_s = 1 | Low | Yes |
+| StreamDiT | c=[1,…,B],s=TNformulae-sequence𝑐  1…𝐵𝑠𝑇𝑁c=[1,\dots,B],s=\frac{T}{N}italic\_c = [ 1 , … , italic\_B ] , italic\_s = divide start\_ARG italic\_T end\_ARG start\_ARG italic\_N end\_ARG | High | Yes |
+
+Table 1: StreamDiT unifies different partitioning schemes.
+
+**Mixed Training:**
+As shown in [Tab. 1](https://arxiv.org/html/2507.03745v2#S3.T1 "In 3.2 Partitioning Scheme ‣ 3 StreamDiT Training ‣ StreamDiT: Real-Time Streaming Text-to-Video Generation"), StreamDiT unifies original diffusion or FM with uniform noise and diagonal noise used by [[20](https://arxiv.org/html/2507.03745v2#bib.bib20), [42](https://arxiv.org/html/2507.03745v2#bib.bib42)]. The latter enables streaming generation but hurts consistency of generated content. To enhance consistency and avoid overfitting, we adopt mixed training with different schemes. This drives the model to learn generalized denoising with different noise levels, instead of memorizing fixed noise levels. It is worth noting that our mixed training covers diffusion and FM training. Therefore, our model can work as a standard T2V generation without streaming. This is also used for initializing our streaming generation.
+
+According to [Fig. 2](https://arxiv.org/html/2507.03745v2#S3.F2 "In 3.2 Partitioning Scheme ‣ 3 StreamDiT Training ‣ StreamDiT: Real-Time Streaming Text-to-Video Generation"), frames in each chunk correspond to a distinct segment of the overall time step range. Thus, during training, we sample a random time step for the i𝑖iitalic\_i-th chunk as follows:
+
+|  |  |  |  |
+| --- | --- | --- | --- |
+|  | τi∼Uniform⁢([TN⋅(i−1),TN⋅i])similar-tosubscript𝜏𝑖Uniform⋅𝑇𝑁𝑖1⋅𝑇𝑁𝑖\tau\_{i}\sim\text{Uniform}\left(\left[\frac{T}{N}\cdot(i-1),\frac{T}{N}\cdot i% \right]\right)italic\_τ start\_POSTSUBSCRIPT italic\_i end\_POSTSUBSCRIPT ∼ Uniform ( [ divide start\_ARG italic\_T end\_ARG start\_ARG italic\_N end\_ARG ⋅ ( italic\_i - 1 ) , divide start\_ARG italic\_T end\_ARG start\_ARG italic\_N end\_ARG ⋅ italic\_i ] ) |  | (8) |
+
+Interestingly, the StreamDiT training can be viewed as parallel training of the full range of denoising.


### PR DESCRIPTION
## Summary
- scrape and summarize arxiv paper "StreamDiT: Real-Time Streaming Text-to-Video Generation"
- capture metadata such as authors, publication date, and OGP image

## Testing
- `pre-commit run --files Summary/2025/07/arxiv.org/2025-07-09_2507-03745v2.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e1e0f0c04832ea2c34e36fc112fa8